### PR TITLE
Add Status Image for RDoc and fix Travis CI own status button.

### DIFF
--- a/docs/user/status-images/index.html
+++ b/docs/user/status-images/index.html
@@ -60,7 +60,12 @@
 <pre><code>[![Build Status](https://secure.travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png)](http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME])
 </code></pre>
 
-<p>Travis CI&rsquo;s own status button looks like this: &ldquo;!https://secure.travis-ci.org/travis-ci/travis-ci.png!&rdquo;:http://travis-ci.org/travis-ci/travis-ci</p>
+<p>Or RDoc:</p>
+
+<pre><code>{&lt;img src="http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME]" /&gt;}[http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME]]
+</code></pre>
+
+<p>Travis CI&rsquo;s own status button looks like this: <a href="http://travis-ci.org/travis-ci/travis-ci"><img src="https://secure.travis-ci.org/travis-ci/travis-ci.png" alt="Build Status" /></a></p>
 
 <h3 id="specifying-branches">Specifying branches</h3>
 

--- a/source/content/docs/user/status-images.md
+++ b/source/content/docs/user/status-images.md
@@ -17,7 +17,11 @@ Or if you're using markdown:
 
     [![Build Status](https://secure.travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png)](http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME])
 
-Travis CI's own status button looks like this: "!https://secure.travis-ci.org/travis-ci/travis-ci.png!":http://travis-ci.org/travis-ci/travis-ci
+Or RDoc:
+
+    {<img src="http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME]" />}[http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME]]
+
+Travis CI's own status button looks like this: [![Build Status](https://secure.travis-ci.org/travis-ci/travis-ci.png)](http://travis-ci.org/travis-ci/travis-ci)
 
 ### Specifying branches
 


### PR DESCRIPTION
Hey guys,

I just added the code snippet to add the build status image to RDoc READMEs. I also fixed the status button example of Travis-CI (it was using the textile format instead of the markdown one).

Cheers!
