### PR TITLE
Use Memcache PHP extension as example

### DIFF
--- a/docs/user/languages/php/index.html
+++ b/docs/user/languages/php/index.html
@@ -109,16 +109,12 @@ php composer.phar install
 
 <h4 id="installing-php-extensions">Installing PHP extensions</h4>
 
-<p>It is possible to install custom PHP extensions into the Travis environment, but they have to be built against the PHP version being tested. Here is for example how the <code>midgard2</code> extension can be installed:</p>
+<p>It is possible to install custom PHP extensions into the Travis environment, but they have to be built against the PHP version being tested. Here is for example how the <code>memcache</code> extension can be installed:</p>
 
-<pre><code>wget https://github.com/midgardproject/midgard-php5/tarball/ratatoskr
-tar zxf ratatoskr
-sh -c "cd midgardproject-midgard-php5-*&amp;&amp;php `pyrus get php_dir|tail -1`/pake.php install"
-</code></pre>
-
-<p>You also need to enable them separately in php.ini:</p>
-
-<pre><code>echo "extension=midgard2.so" &gt;&gt; `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` 
+<pre><code>wget http://pecl.php.net/get/memcache-2.2.6.tgz
+tar -xzf memcache-2.2.6.tgz
+sh -c "cd memcache-2.2.6 &amp;&amp; phpize &amp;&amp; ./configure --enable-memcache &amp;&amp; make &amp;&amp; sudo make install"
+echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 </code></pre>
 
 <p>See also the <a href="https://github.com/bergie/midgardmvc_core/blob/master/tests/travis_midgard.sh">full before_script using midgard2</a>.</p>


### PR DESCRIPTION
Not all PHP extensions support pake.php so installing the Memcache extension is a more generic example.
