### PR TITLE
after_script will only be run when the build succeeded

### DIFF
--- a/docs/user/build-configuration/index.html
+++ b/docs/user/build-configuration/index.html
@@ -113,6 +113,7 @@ after_script:
 </code></pre>
 
 <p>These scripts can, e.g., be used to setup databases or other build setup tasks. For more information about database setup see <a href="/docs/user/database-setup/">Database setup</a>.</p>
+<p><strong>NOTE:</strong> The command(s) in <code>after_script</code> will only run if the build succeeded (when <code>script</code> returns 0).</p>
 
 <h3 id="install">install</h3>
 


### PR DESCRIPTION
That is useful to know, so I added a note to the build configuration guide.
