### PR TITLE
JSONP Documentation

### DIFF
--- a/docs/dev/api/index.html
+++ b/docs/dev/api/index.html
@@ -190,6 +190,88 @@
 
 <p><a href="http://hurl.it/hurls/e69fc3c78fe69ed27e4ef772af5ac6bf005bffce/af2ecf26f637b4cf16b112a35179f9c4277d5b0c">Hurl</a></p>
 
+<h3 id="jsonp">JSONP</h3>
+
+<p>The server acknowledges <a href="http://en.wikipedia.org/wiki/JSONP" title="Wikipedia on JSONP">JSONP</a> requests. This allows
+a javascript client to relax the 
+<a href="http://en.wikipedia.org/wiki/Same_origin_policy" title="Wikipedia on Same Origin Policy">same origin policy</a>
+and retrieve the above json by specifying a callback function.</p>
+
+<h4 id="example">Example</h4>
+
+<p>JSONP works with any of the above urls. The example below uses the url for builds and appends a callback</p>
+
+<pre><code>http://travis-ci.org/:owner_name/:name/builds.json?callback=:function
+</code></pre>
+
+<h4 id="response-httptravis-ciorgtravis-citravis-cibuildsjsoncallbackfoo">Response (http://travis-ci.org/travis-ci/travis-ci/builds.json?callback=foo)</h4>
+
+<pre><code>foo(
+  [
+    {
+      "number": "731",
+      "committed_at": "2011-08-02T23:16:51Z",
+      "commit": "9b5786d7164ef5a960e0d7b87764b9cbc0fb95e3",
+      "finished_at": "2011-08-02T23:27:17Z",
+      "config": {
+        "script": "bundle exec rake test:ci",
+        ".configured": "true",
+        "bundler_args": "--without development",
+        "notifications": {
+          "irc": "irc.freenode.org#travis"
+        },
+        "rvm": [
+          "1.8.7",
+          "1.9.2",
+          "1.9.3",
+          "ree"
+        ]
+      },
+      "author_name": "Josh Kalderimis",
+      "matrix": [
+        {
+          "number": "731.1",
+          "committed_at": "2011-08-02T23:16:51Z",
+          "commit": "9b5786d7164ef5a960e0d7b87764b9cbc0fb95e3",
+          "finished_at": "2011-08-02T23:24:06Z",
+          "config": {
+            "script": "bundle exec rake test:ci",
+            ".configured": "true",
+            "bundler_args": "--without development",
+            "notifications": {
+              "irc": "irc.freenode.org#travis"
+            },
+            "rvm": "1.8.7"
+          },
+          "author_name": "Josh Kalderimis",
+          "log": "Using worker: main.railshoster:worker-3\n\n$ git clone --depth=1000 --quiet git://github.com/travis-ci/travis-ci.git ... ",
+          "branch": "master",
+          "id": 63812,
+          "parent_id": 63811,
+          "started_at": "2011-08-02T23:20:13Z",
+          "author_email": "josh.kalderimis@gmail.com",
+          "status": 0,
+          "repository_id": 59,
+          "message": "Merge branch 'staging'",
+          "compare_url": "https://github.com/travis-ci/travis-ci/compare/ca5b190...9b5786d"
+        },
+       ...
+      ],
+      "log": "",
+      "branch": "master",
+      "id": 63811,
+      "started_at": "2011-08-02T23:23:05Z",
+      "author_email": "josh.kalderimis@gmail.com",
+      "status": 0,
+      "repository_id": 59,
+      "message": "Merge branch 'staging'",
+      "compare_url": "https://github.com/travis-ci/travis-ci/compare/ca5b190...9b5786d"
+    },
+    ...
+  ]
+)
+</code></pre>
+
           </div><!-- /#main -->
           <div id="sidebar">
             <h2>Contact</h2>

--- a/source/content/docs/dev/api.md
+++ b/source/content/docs/dev/api.md
@@ -150,3 +150,84 @@ kind: content
     }
 
 [Hurl](http://hurl.it/hurls/e69fc3c78fe69ed27e4ef772af5ac6bf005bffce/af2ecf26f637b4cf16b112a35179f9c4277d5b0c)
+
+### JSONP
+
+The server acknowledges [JSONP](http://en.wikipedia.org/wiki/JSONP "Wikipedia on JSONP") requests. This allows
+a javascript client to relax the 
+[same origin policy](http://en.wikipedia.org/wiki/Same_origin_policy "Wikipedia on Same Origin Policy")
+and retrieve the above json by specifying a callback function.
+
+#### Example
+
+JSONP works with any of the above urls. The example below uses the url for builds and appends a callback
+
+    http://travis-ci.org/:owner_name/:name/builds.json?callback=:function
+
+#### Response (http://travis-ci.org/travis-ci/travis-ci/builds.json?callback=foo)
+
+    foo(
+      [
+        {
+          "number": "731",
+          "committed_at": "2011-08-02T23:16:51Z",
+          "commit": "9b5786d7164ef5a960e0d7b87764b9cbc0fb95e3",
+          "finished_at": "2011-08-02T23:27:17Z",
+          "config": {
+            "script": "bundle exec rake test:ci",
+            ".configured": "true",
+            "bundler_args": "--without development",
+            "notifications": {
+              "irc": "irc.freenode.org#travis"
+            },
+            "rvm": [
+              "1.8.7",
+              "1.9.2",
+              "1.9.3",
+              "ree"
+            ]
+          },
+          "author_name": "Josh Kalderimis",
+          "matrix": [
+            {
+              "number": "731.1",
+              "committed_at": "2011-08-02T23:16:51Z",
+              "commit": "9b5786d7164ef5a960e0d7b87764b9cbc0fb95e3",
+              "finished_at": "2011-08-02T23:24:06Z",
+              "config": {
+                "script": "bundle exec rake test:ci",
+                ".configured": "true",
+                "bundler_args": "--without development",
+                "notifications": {
+                  "irc": "irc.freenode.org#travis"
+                },
+                "rvm": "1.8.7"
+              },
+              "author_name": "Josh Kalderimis",
+              "log": "Using worker: main.railshoster:worker-3\n\n$ git clone --depth=1000 --quiet git://github.com/travis-ci/travis-ci.git ... ",
+              "branch": "master",
+              "id": 63812,
+              "parent_id": 63811,
+              "started_at": "2011-08-02T23:20:13Z",
+              "author_email": "josh.kalderimis@gmail.com",
+              "status": 0,
+              "repository_id": 59,
+              "message": "Merge branch 'staging'",
+              "compare_url": "https://github.com/travis-ci/travis-ci/compare/ca5b190...9b5786d"
+            },
+           ...
+          ],
+          "log": "",
+          "branch": "master",
+          "id": 63811,
+          "started_at": "2011-08-02T23:23:05Z",
+          "author_email": "josh.kalderimis@gmail.com",
+          "status": 0,
+          "repository_id": 59,
+          "message": "Merge branch 'staging'",
+          "compare_url": "https://github.com/travis-ci/travis-ci/compare/ca5b190...9b5786d"
+        },
+        ...
+      ]
+    )
+


### PR DESCRIPTION
Commit travis-ci/travis-ci#432 implements the feature request in issue travis-ci/travis-ci#431 i.e
that the travis server responds to JSONP requests.

The API documentation is extended with a section which details
the JSONP urls.
