### PR TITLE
Fixed a typo (IRC notifications -> webhook payloads).

### DIFF
--- a/docs/user/build-configuration/index.html
+++ b/docs/user/build-configuration/index.html
@@ -365,7 +365,7 @@ branches:
     - http://another-domain.com/notifications
 </code></pre>
 
-<p>Just as with other notification types you can specify when IRC notifications will be sent:</p>
+<p>Just as with other notification types you can specify when webhook payloads will be sent:</p>
 
 <pre><code>notifications:
   webhooks:


### PR DESCRIPTION
Fixed a quick Copy/Paste related typo in the documentation (webhook payloads != IRC notifications).
