### PR TITLE
Fixed the IRC typo in source, and linkified the webhook example gist.

### DIFF
--- a/source/content/docs/user/build-configuration.md
+++ b/source/content/docs/user/build-configuration.md
@@ -339,7 +339,7 @@ Or multiple channels:
         - http://your-domain.com/notifications
         - http://another-domain.com/notifications
 
-Just as with other notification types you can specify when IRC notifications will be sent:
+Just as with other notification types you can specify when webhook payloads will be sent:
 
     notifications:
       webhooks:
@@ -349,7 +349,7 @@ Just as with other notification types you can specify when IRC notifications wil
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
 
-Here is an example payload of what will be `POST`ed to your webhook URLs: https://gist.github.com/1225015
+Here is an example payload of what will be `POST`ed to your webhook URLs: [gist.github.com/1225015](https://gist.github.com/1225015)
 
 
 


### PR DESCRIPTION
Properly fixed the typo in source, and made the webhook gist a link.
