### PR TITLE
small update to python docs: add URL for Deadsnakes PPA

### DIFF
--- a/docs/user/languages/python/index.html
+++ b/docs/user/languages/python/index.html
@@ -40,7 +40,7 @@
 
 <h2 id="choosing-python-versions-to-test-against">Choosing Python versions to test against</h2>
 
-<p>Python workers on travis-ci.org use default Ubuntu/Debian apt repositories plus <a href="">Dead Snakes PPA</a> to provide several Python versions your projects can be
+<p>Python workers on travis-ci.org use default Ubuntu/Debian apt repositories plus <a href="https://launchpad.net/~fkrull/+archive/deadsnakes">Dead Snakes PPA</a> to provide several Python versions your projects can be
 tested against. To specify them, use <code>python:</code> key in your <code>.travis.yml</code> file, for example:</p>
 
 <pre><code>language: python


### PR DESCRIPTION
I noticed that the python docs are missing a URL for the Deadsnakes PPA (it just says href=""). This fills in the missing string.
