### PR TITLE
adding firefox addon details to browser extension page

### DIFF
--- a/docs/user/browser-extensions/index.html
+++ b/docs/user/browser-extensions/index.html
@@ -42,6 +42,10 @@
 
 <h3 id="travis-ciorg-build-status-extension-for-chromehttpschromegooglecomwebstoredetailklbmicjanlggbmanmpneloekhajhhbfb"><a href="https://chrome.google.com/webstore/detail/klbmicjanlggbmanmpneloekhajhhbfb">travis-ci.org Build Status Extension for Chrome</a></h3>
 <p><a href="https://chrome.google.com/webstore/detail/klbmicjanlggbmanmpneloekhajhhbfb">travis-ci.org Build Status Extension for Chrome</a> displays the build status icon next to the project name on GitHub.</p>
+<h2 id="firefox">Firefox</h2>
+
+<h3 id="travis-ciorg-build-status-extension-for-firefoxhttpsaddonsmozillaorgen-USfirefoxaddongithubtravis"><a href="https://addons.mozilla.org/en-US/firefox/addon/githubtravis/">travis-ci.org Build Status Extension for Firefox</a></h3>
+<p><a href="https://addons.mozilla.org/en-US/firefox/addon/githubtravis/">travis-ci.org Build Status Extension for Firefox</a> displays the build status icon next to the project name on GitHub.</p>
 
           </div><!-- /#main -->
           <div id="sidebar">


### PR DESCRIPTION
This is a mirror of the Chrome extension for Firefox.
