### PR TITLE
Fixing key for PHP build configuration.

### DIFF
--- a/source/content/docs/user/build-configuration.md
+++ b/source/content/docs/user/build-configuration.md
@@ -180,9 +180,9 @@ Learn more about <a href="/docs/user/languages/perl/">.travis.yml options for Pe
 
 ### PHP
 
-PHP projects specify releases they need to be tested against using `phps` key:
+PHP projects specify releases they need to be tested against using `php` key:
 
-    phps:
+    php:
       - 5.3
       - 5.4
 


### PR DESCRIPTION
The key used for PHP build configuration is `php` not `phps`
