### PR TITLE
Update Erlang documentation

### DIFF
--- a/docs/user/languages/erlang.md
+++ b/docs/user/languages/erlang.md
@@ -39,5 +39,6 @@ to installs project's [dependencies as listed in the rebar.config file](https://
 
 ## Examples
 
-* [cowboy](https://github.com/extend/cowboy/blob/master/.travis.yml)
-* [elixir](https://github.com/josevalim/elixir/blob/master/.travis.yml)
+* [elixir](https://github.com/elixir-lang/elixir/blob/master/.travis.yml)
+* [mochiweb](https://github.com/mochi/mochiweb/blob/master/.travis.yml)
+* [ibrowse](https://github.com/cmullaparthi/ibrowse/blob/master/.travis.yml)


### PR DESCRIPTION
- Proper link for the Elxir repo
- According to this https://github.com/extend/cowboy/commit/0c3cf802b429258e2a6ff924156c8d330de5c7e1 commit Cowboy dropped Travis CI test running, so I think we should replace this example with something else, so I propose to include `ibrowse` and `mochiweb`, they are the only to repos using Travis that I could quikly find.
