### PR TITLE
Add a new link to a PHP extension installation sample

### DIFF
--- a/docs/user/languages/php.md
+++ b/docs/user/languages/php.md
@@ -111,7 +111,7 @@ It is possible to install custom PHP extensions into the Travis environment, but
     sh -c "cd memcache-2.2.6 && phpize && ./configure --enable-memcache && make && sudo make install"
     echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
-See also the [full before_script using midgard2](https://github.com/bergie/midgardmvc_core/blob/master/tests/travis_midgard.sh).
+See also the [full before_script using midgard2](https://github.com/bergie/midgardmvc_core/blob/master/tests/travis_midgard.sh) or another one for [mongo php driver](https://gist.github.com/2351174).
 
 ### Chef Cookbooks for PHP
 

--- a/fr/docs/user/languages/php.md
+++ b/fr/docs/user/languages/php.md
@@ -155,7 +155,7 @@ installée:
     sh -c "cd memcache-2.2.6 && phpize && ./configure --enable-memcache && make && sudo make install"
     echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
-Voir aussi [midgard2 utilisant pleinement before_script](https://github.com/bergie/midgardmvc_core/blob/master/tests/travis_midgard.sh).
+Voir aussi [midgard2 utilisant pleinement before_script](https://github.com/bergie/midgardmvc_core/blob/master/tests/travis_midgard.sh) ainsi que l'installation du [driver php mongo](https://gist.github.com/2351174).
 
 
 ### Livres de cuisine du chef pour PHP


### PR DESCRIPTION
as @svenfuchs suggested me, I added a link to a gist containing a full sample of **before_script** use when installing the requested [Mongo PHP extension](http://pecl.php.net/package/mongo). I made updates in _english_ and _french_.
