### PR TITLE
[minor] Update links to Scala Examples: Refer to official projects (Scalatra and Salat)

### DIFF
--- a/docs/user/languages/scala.md
+++ b/docs/user/languages/scala.md
@@ -34,5 +34,6 @@ Because Scala builder on travis-ci.org assumes SBT dependency management is used
 ## Examples
 
 * [twitter/scalding](https://github.com/twitter/scalding/blob/master/.travis.yml)
-* [gildegoma/scalatra](https://github.com/gildegoma/scalatra/blob/add-travis-ci/.travis.yml)
-* [gildegoma/salat](https://github.com/gildegoma/salat/blob/add-travis-ci/.travis.yml)
+* [scalatra/scalatra](https://github.com/scalatra/scalatra/blob/develop/.travis.yml)
+* [novus/salat](https://github.com/novus/salat/blob/master/.travis.yml)
+


### PR DESCRIPTION
Since Scalatra and Salat projects are now officially plugged with Travis CI, it is far better to directly reference them instead of my former testing forks.

Cheers, Gilles
