### PR TITLE
A workaround for Jython

### DIFF
--- a/docs/user/resources.md
+++ b/docs/user/resources.md
@@ -13,3 +13,4 @@ Here are some blog posts about Travis:
 * [Building Node.js projects with Travis](http://labnotes.org/2011/08/10/building-node-js-projects-with-travis/)
 * [Using RVM gemset imports on Travis CI instead of Bundler](http://manveru.name/blog/show/2011-12-08/en/Simplified-Travis-CI-RVM)
 * [Display Travis CI status in your shell prompt](http://madebynathan.com/2012/01/30/travis-ci-status-in-shell-prompt/)
+* [Use Travis CI with Jython](http://dev.hong.me/blog/2012/05/27/use-travis-ci-with-jython/)


### PR DESCRIPTION
On [this doc page](http://about.travis-ci.org/docs/user/ci-environment/), the Travis CI environments are listed. Jython is not officially supported. But I've written [a blog](http://dev.hong.me/blog/2012/05/27/use-travis-ci-with-jython/) to describe a workaround for Jython. I think this is a useful blog and I think the link could be on the [environment doc page](http://about.travis-ci.org/docs/user/ci-environment/). What do you think about it?

It could be just a note like this in the Python section:

> Jython is not officially supported yet, but you can check [this page](http://dev.hong.me/blog/2012/05/27/use-travis-ci-with-jython/) for a workaround.

Thanks!
