### PR TITLE
Travis+GitHub Extension for Opera Browser

### DIFF
--- a/docs/user/browser-extensions.md
+++ b/docs/user/browser-extensions.md
@@ -11,3 +11,7 @@ permalink: browser-extensions/
 ### Firefox
 
 [Travis CI Build Status Extension for Firefox](https://addons.mozilla.org/en-US/firefox/addon/githubtravis/) displays the build status icon next to the project name on GitHub.
+
+### Opera
+
+[Travis CI Build Status Extension for Opera](https://addons.opera.com/en/extensions/details/travisgithub/) displays the build status icon next to the project name on GitHub project/user pages and provides button for monitoring build status of user-defined projects.


### PR DESCRIPTION
Hello, I've created a Travis+GitHub extension for Opera Browser with similar functionality as the ones for Chrome and Firefox:
- Shows build status badge next to the project name on GitHub.
- Shows the badge on a user/organization page (status for all the repos).
- Provides a button for monitoring build status of user-defined projects.
