### PR TITLE
Add --quiet flag

### DIFF
--- a/docs/user/languages/php.md
+++ b/docs/user/languages/php.md
@@ -76,7 +76,7 @@ and then use ENV variable values in any later script like your dependencies inst
 Here is an example using the above ENV variable to modify the dependencies when using the composer package manager to run the tests against the 2 differnt versions of Symfony as defined above.
 
     before_script:
-       - curl -s http://getcomposer.org/installer | php --
+       - curl -s http://getcomposer.org/installer | php -- --quiet
        - php composer.phar require symfony/framework-bundle:${SYMFONY_VERSION}
 
 Here we use DB variable value to pick phpunit configuration file:


### PR DESCRIPTION
It just kills off a few lines of redundant output, and errors (which really shouldn't happen unless getcomposer.org is down) are still shown.
