### PR TITLE
Use `apt-get -qq` to reduce the amount of noise in builds

### DIFF
--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -273,7 +273,7 @@ permalink: api/
               "ctest -V ."
             ], 
             "install": [
-              "sudo apt-get install cmake"
+              "sudo apt-get install -qq cmake"
             ], 
             ".result": "configured"
           }
@@ -334,7 +334,7 @@ permalink: api/
           ]
         }, 
         "before_install": [
-          "sudo apt-get install libgmp3-dev", 
+          "sudo apt-get install -qq libgmp3-dev", 
           "mysql -e 'create database browserid;'"
         ], 
         "env": "WHAT_TESTS=back_mysql MYSQL_USER=root", 

--- a/docs/user/build-configuration.md
+++ b/docs/user/build-configuration.md
@@ -275,8 +275,8 @@ With this configuration, **4 individual builds** will be triggered:
 If your dependencies need native libraries to be available, **you can use passwordless sudo to install them** with
 
     before_install:
-     - sudo apt-get update
-     - sudo apt-get install [packages list]
+     - sudo apt-get update -qq
+     - sudo apt-get install -qq [packages list]
 
 The reason why travis-ci.org can afford to provide passwordless sudo is that virtual machines your test suite is executed in are
 snapshotted and rolled back to their pristine state after each build.

--- a/docs/user/ci-environment.md
+++ b/docs/user/ci-environment.md
@@ -100,7 +100,7 @@ Language-specific workers have multiple runtimes for their respective language (
 
 ### apt configuration
 
-apt is configured to not require confirmation (assume -y switch by default) using both `DEBIAN_FRONTEND` env variable and apt configuration file). This means `apt-get install` can be used without the -y flag.
+apt is configured to not require confirmation (assume -y switch by default) using both `DEBIAN_FRONTEND` env variable and apt configuration file). This means `apt-get install -qq` can be used without the -y flag.
 
 ## JVM (Clojure, Groovy, Java, Scala) VM images
 

--- a/pt-BR/docs/user/build-configuration.md
+++ b/pt-BR/docs/user/build-configuration.md
@@ -264,8 +264,8 @@ With this configuration, **4 individual builds** will be triggered:
 If your dependencies need native libraries to be available, **you can use passwordless sudo to install them** with
 
     before_install:
-     - sudo apt-get update
-     - sudo apt-get install [packages list]
+     - sudo apt-get update -qq
+     - sudo apt-get install -qq [packages list]
 
 The reason why travis-ci.org can afford to provide passwordless sudo is that virtual machines your test suite is executed in are
 snapshotted and rolled back to their pristine state after each build.

--- a/pt-BR/docs/user/ci-environment.md
+++ b/pt-BR/docs/user/ci-environment.md
@@ -89,7 +89,7 @@ Language-specific workers have multiple runtimes for their respective language (
 
 ### apt configuration
 
-apt is configured to not require confirmation (assume -y switch by default) using both `DEBIAN_FRONTEND` env variable and apt configuration file). This means `apt-get install` can be used without the -y flag.
+apt is configured to not require confirmation (assume -y switch by default) using both `DEBIAN_FRONTEND` env variable and apt configuration file). This means `apt-get install -qq` can be used without the -y flag.
 
 ## JVM (Clojure, Groovy, Java, Scala) VM images
 


### PR DESCRIPTION
The default install/update is pretty noisy with apt. This updates the documentation use `-qq` which tells apt to only display errors. 
