### PR TITLE
Add blog post on repositories sync

### DIFF
--- a/blog/_posts/2012-08-02-your-repositories-now-sync-automagically.md
+++ b/blog/_posts/2012-08-02-your-repositories-now-sync-automagically.md
@@ -2,7 +2,7 @@
 title: "Travis Now Syncs Your Repositories Automagically"
 layout: post
 created_at: thu aug 02 15:30:26 cest 2012
-permalink: blog/2012-08-01-travis-now-syncs-your-repositories-automagically
+permalink: blog/2012-08-02-travis-now-syncs-your-repositories-automagically
 author: Mathias Meyer
 twitter: roidrage
 ---


### PR DESCRIPTION
This is not fully done yet, it's missing a screenshot for "My Repositories", but that tab currently shows all of the repositories that are part of all of a user's organizations.
