### PR TITLE
Fix irc:// URIs

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -39,7 +39,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net#travis">IRC</a></li>
+              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Mailing list</a></li>
               <li><a href="http://github.com/travis-ci">Github</a></li>
             </ul>

--- a/_layouts/es.html
+++ b/_layouts/es.html
@@ -39,7 +39,7 @@
             <h2>Contacto</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net#travis">IRC</a></li>
+              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Lista de Correos</a></li>
               <li><a href="http://github.com/travis-ci">Github</a></li>
             </ul>

--- a/_layouts/fr.html
+++ b/_layouts/fr.html
@@ -54,7 +54,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net#travis">IRC</a></li>
+              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Liste de diffusion</a></li>
               <li><a href="http://github.com/travis-ci">Github</a></li>
             </ul>

--- a/_layouts/pt-BR.html
+++ b/_layouts/pt-BR.html
@@ -39,7 +39,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net#travis">IRC</a></li>
+              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Lista de email</a></li>
               <li><a href="http://github.com/travis-ci">Github</a></li>
             </ul>

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -259,4 +259,4 @@ See [Database setup](/docs/user/database-setup/) to learn how to configure a dat
 
 ### Step seven: We are here to help!
 
-For any kind of questions feel free to join our IRC channel [#travis on irc.freenode.net](irc://irc.freenode.net#travis). We're there to help :)
+For any kind of questions feel free to join our IRC channel [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis). We're there to help :)

--- a/es/docs/user/getting-started.md
+++ b/es/docs/user/getting-started.md
@@ -200,4 +200,4 @@ Mira [Configuración de Base de datos](/docs/user/database-setup/) para aprender
 
 ### Paso 7: Estamos aquí para ayudar!
 
-Para cualquier duda sientete libre de conectarte a nuestro canal de IRC [#travis en irc.freenode.net](irc://irc.freenode.net#travis). Estamos para ayudarte :)
+Para cualquier duda sientete libre de conectarte a nuestro canal de IRC [#travis en irc.freenode.net](irc://irc.freenode.net/%23travis). Estamos para ayudarte :)

--- a/es/index.md
+++ b/es/index.md
@@ -30,4 +30,4 @@ Los servicios y librerías que hace posible travis-ci.org están [alojadas en Gi
 
 ## Conoce al Equipo
 
-Si sientes que este es un gran proyecto visitanos en [#travis on irc.freenode.net](irc://travis#irc.freenode.net) y saluda! Y no olvides de visitar el  [Travis Blog](/blog/)!
+Si sientes que este es un gran proyecto visitanos en [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis) y saluda! Y no olvides de visitar el  [Travis Blog](/blog/)!

--- a/fr/2011/welcome-to-travis.md
+++ b/fr/2011/welcome-to-travis.md
@@ -9,4 +9,4 @@ Travis CI est un système open-source d'intégration continue, pour la communaut
 Nous prévoyons d'avoir un blog sous peu mais pour l'instant vous pouvez
 lire nos *idées initiales* sur le [blog en anglais de Sven](http://svenfuchs.com/2011/2/5/travis-a-distributed-build-server-tool-for-the-ruby-community") et lire les diapositives des présentations que nous avons faites lors de conférences (dont [Ruby Lugdunum](http://rulu.eu), à Lyon) et User Groups Ruby.
 
-Si vous souhaitez nous rejoindre sur IRC, rendez-vous sur [#travis on irc.freenode.net](irc://travis#irc.freenode.net)
+Si vous souhaitez nous rejoindre sur IRC, rendez-vous sur [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis)

--- a/fr/docs/user/getting-started.md
+++ b/fr/docs/user/getting-started.md
@@ -201,4 +201,4 @@ Lisez [Configurer une base de données](/fr/docs/user/database-setup/) pour appr
 
 ### Etape n°7 : Nous sommes là pour vous aider !
 
-Quelque soit votre question, n'hésitez pas à rejoindre notre canal IRC [#travis sur irc.freenode.net](irc://irc.freenode.net#travis). On sera là pour vous aider ;). Bien que la lingua franca du canal soit l'anglais, vous pourrez aussi y trouver quelques francophones pour vous aider !
+Quelque soit votre question, n'hésitez pas à rejoindre notre canal IRC [#travis sur irc.freenode.net](irc://irc.freenode.net/%23travis). On sera là pour vous aider ;). Bien que la lingua franca du canal soit l'anglais, vous pourrez aussi y trouver quelques francophones pour vous aider !

--- a/fr/index.md
+++ b/fr/index.md
@@ -30,5 +30,5 @@ Les services et les librairies qui font fonctionner travis-ci.org sont [héberg�
 
 ## Rencontrez l'équipe
 
-N'hésitez pas à venir nous passer le bonjour sur [#travis sur irc.freenode.net](irc://travis#irc.freenode.net) si vous trouvez le projet génial !
+N'hésitez pas à venir nous passer le bonjour sur [#travis sur irc.freenode.net](irc://irc.freenode.net/%23travis) si vous trouvez le projet génial !
 Et n'oubliez pas de jeter un oeil sur le [Blog](/blog/) !

--- a/index.md
+++ b/index.md
@@ -32,4 +32,4 @@ Services and libraries that make travis-ci.org work are [hosted on GitHub](https
 
 ## Meet the Team
 
-If you feel like this is a great project then jump into [#travis on irc.freenode.net](irc://travis#irc.freenode.net) and say hi! And don't forget to check out the [Travis Blog](/blog/)!
+If you feel like this is a great project then jump into [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis) and say hi! And don't forget to check out the [Travis Blog](/blog/)!

--- a/pt-BR/docs/user/getting-started.md
+++ b/pt-BR/docs/user/getting-started.md
@@ -200,4 +200,4 @@ Leia [Configuração de Banco de Dados](/pt-BR/docs/user/database-setup/) para a
 
 ### Sétimo passo: Estamos aqui para ajudar!
 
-Para qualquer tipo de pergunta, sinta-se livre para entrar em nosso canal de IRC [#travis na rede irc.freenode.net](irc://irc.freenode.net#travis). Estamos aqui para ajudar! :)
+Para qualquer tipo de pergunta, sinta-se livre para entrar em nosso canal de IRC [#travis na rede irc.freenode.net](irc://irc.freenode.net/%23travis). Estamos aqui para ajudar! :)

--- a/pt-BR/index.md
+++ b/pt-BR/index.md
@@ -29,4 +29,4 @@ Os serviços e bibliotecas que fazem o travis-ci.org funcionar estão [disponív
 
 ## Encontre o time
 
-Se você acha que este é um grande projeto, então vá para o [#travis nada rede irc.freenode.net](irc://travis#irc.freenode.net) e diga oi! E não se esqueça de checar o [Travis Blog](/blog/)!
+Se você acha que este é um grande projeto, então vá para o [#travis nada rede irc.freenode.net](irc://irc.freenode.net/%23travis) e diga oi! E não se esqueça de checar o [Travis Blog](/blog/)!


### PR DESCRIPTION
See http://tools.ietf.org/html/draft-butcher-irc-url-04#section-2.5.1
which comments that `%23` should be used instead of `#` (because a
channel name is part of the [path of the
URI](http://tools.ietf.org/html/rfc3986#section-3.3), not [the
fragment](http://tools.ietf.org/html/rfc3986#section-3.5)).
