### PR TITLE
change property name to skip tests to maven.test.skip

### DIFF
--- a/docs/user/languages/java.md
+++ b/docs/user/languages/java.md
@@ -32,7 +32,7 @@ to run your test suite. This can be overriden as described in the [general build
 
 Before running tests, Java builder will execute
 
-    mvn install -DskipTests=true
+    mvn install -Dmaven.test.skip=true
 
 to install your project's dependencies with Maven.
 


### PR DESCRIPTION
The maven.test.skip property is also accepted by none surfire test plugins such as tycho for example.
see https://issues.sonatype.org/browse/TYCHO-123 and http://maven.apache.org/plugins/maven-surefire-plugin/examples/skipping-test.html
