### PR TITLE
Improve documentation on encrypting files.

### DIFF
--- a/docs/user/travis-pro.md
+++ b/docs/user/travis-pro.md
@@ -173,3 +173,7 @@ before_install:
 This way, the deploy key is never exposed to parties you don't want it exposed
 to. The same note as with the encryption scheme applies here too, though: when a
 malicious party tampers with your build script, the key could still be exposed.
+
+It also must be noted that subsequent accesses to the original processes, should
+they be required by your build, won't be possible without assigning the
+secondary deploy key to the original repository as well.


### PR DESCRIPTION
This improves the documentation reflecting the fact that an RSA key isn't enough to encrypt larger files. It improves it by using a symmetric AES-256 encryption for the data and the encrypts only the secret for that using the RSA public key.
