### PR TITLE
Replace “Github” with “GitHub”

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -52,7 +52,7 @@
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
               <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Mailing list</a></li>
-              <li><a href="http://github.com/travis-ci">Github</a></li>
+              <li><a href="http://github.com/travis-ci">GitHub</a></li>
             </ul>
             <h2>Guides</h2>
             <ul>

--- a/_layouts/fr.html
+++ b/_layouts/fr.html
@@ -69,7 +69,7 @@
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
               <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Liste de diffusion</a></li>
-              <li><a href="http://github.com/travis-ci">Github</a></li>
+              <li><a href="http://github.com/travis-ci">GitHub</a></li>
             </ul>
             <h2>Documentation utilisateur</h2>
             <ul>

--- a/_layouts/pt-BR.html
+++ b/_layouts/pt-BR.html
@@ -52,7 +52,7 @@
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
               <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Lista de email</a></li>
-              <li><a href="http://github.com/travis-ci">Github</a></li>
+              <li><a href="http://github.com/travis-ci">GitHub</a></li>
             </ul>
             <h2>Guias</h2>
             <ul>

--- a/docs/dev/build_tasks.md
+++ b/docs/dev/build_tasks.md
@@ -16,7 +16,7 @@ The following classes encapsulate the application domain model concepts. I.e. th
 
 ### Request
 
-A Request is what external services, like currently Github, send to Travis Server. It contains the sent payload and has a one-to-one relationship to a Build.
+A Request is what external services, like currently GitHub, send to Travis Server. It contains the sent payload and has a one-to-one relationship to a Build.
 
 ### Build
 
@@ -82,7 +82,7 @@ When a build request comes in then a Request and a Build is created. The Build w
 
 The worker will pick up the Task::Configure and start working on it. It will send messages back to the application which will trigger state changes on the respective Task::Configure on the server side.
 
-If the Task::Configure errors then the containing Build will immediately go into the same state and stop proceeding. (At a later stage we might retry the errored task for particular reasons, like Github was down.)
+If the Task::Configure errors then the containing Build will immediately go into the same state and stop proceeding. (At a later stage we might retry the errored task for particular reasons, like GitHub was down.)
 
 Once the Task::Configure has finished and the build is approved then the Build will create and queue one or more Tasks according to the configuration (for starters these will be at least one Task::Test).
 
@@ -98,7 +98,7 @@ So, in more detail:
 
 ### Build creation
 
-* Github pings
+* GitHub pings
 * Server creates a Request
 * Server creates a Build with the Request
 * Server emits a build:created event

--- a/docs/user/build-configuration.md
+++ b/docs/user/build-configuration.md
@@ -131,7 +131,7 @@ This will include nested submodules (submodules of submodules), in case there ar
 
 ### Use Public URLs For Submodules
 
-If your project uses git submodules, make sure you use public git URLs. For example, for Github instead of
+If your project uses git submodules, make sure you use public git URLs. For example, for GitHub instead of
 
     git@github.com:someuser/somelibrary.git
 
@@ -495,7 +495,7 @@ Here is an example payload of what will be `POST`ed to your webhook URLs: [gist.
 
 #### Authorization
 When Travis makes the POST request, a header named 'Authorization' is included.  It's value is the SHA2 hash of your
-Github username, the name of the repository, and your Travis token.  In python,
+GitHub username, the name of the repository, and your Travis token.  In python,
 
     from hashlib import sha256
     sha256('username/repository' + TRAVIS_TOKEN).hexdigest()

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -33,9 +33,9 @@ please take care to only use a reasonable amount of workers time.
 
 ### Step one: Sign in
 
-To get started with Travis CI, sign in through Github OAuth. Go to [Travis CI](http://travis-ci.org) and follow the Sign In link at the top.
+To get started with Travis CI, sign in through GitHub OAuth. Go to [Travis CI](http://travis-ci.org) and follow the Sign In link at the top.
 
-Github will ask you for granting read- and write access. Travis CI needs write access for setting up service hooks for your repositories when you request it, but it won't touch anything else.
+GitHub will ask you for granting read- and write access. Travis CI needs write access for setting up service hooks for your repositories when you request it, but it won't touch anything else.
 
 ### Step two: Activate GitHub Service Hook
 

--- a/docs/user/status-images.md
+++ b/docs/user/status-images.md
@@ -12,7 +12,7 @@ We recommend you start with the [Getting Started](/docs/user/getting-started/) a
 
 ## Status Image URLs
 
-After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on Github or your project website.
+After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on GitHub or your project website.
 
     https://secure.travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png
 

--- a/es/docs/user/getting-started.md
+++ b/es/docs/user/getting-started.md
@@ -6,7 +6,7 @@ permalink: getting-started/
 
 ### Travis CI Overview
 
-Travis CI es un sistema de integración continua para la comunidad OpenSource. Está integrado con Github y ofrece soporte de primera clase para:
+Travis CI es un sistema de integración continua para la comunidad OpenSource. Está integrado con GitHub y ofrece soporte de primera clase para:
 
 * [Clojure](/docs/user/languages/clojure)
 * [Erlang](/docs/user/languages/erlang)
@@ -28,7 +28,7 @@ travis-ci.org originalmente comenzó como un servicio para la comunidad Ruby a i
 
 Para comenzar con Travis CI debes registrarte, puedes hacerlo usando tu cuenta de GitHub. Ve a [Travis CI](http://travis-ci.org) y haz clic en el enlace "Iniciar sesión con GitHub" en la parte superior.
 
-Github te pedirá que des permiso de lectura y escritura. Travis CI necesita permiso de escritura para configurar automáticamente el Hook de servicio para tus repositorios según lo solicites. Pero no tocará nada mas.
+GitHub te pedirá que des permiso de lectura y escritura. Travis CI necesita permiso de escritura para configurar automáticamente el Hook de servicio para tus repositorios según lo solicites. Pero no tocará nada mas.
 
 ### Paso Dos: Activar el Hook de Servicio de GitHub
 
@@ -182,9 +182,9 @@ y algunas mas. `travis-lint` es tu amigo, ¡úsalo!.
 
 ### Paso Cuatro: Lanzar tu primera construcción haciendo Git Push
 
-Una vez configurado el Hook de Github, puedes hacer push a tu commit añadiendo el .travis.yml a tu repositorio. Esto hará que tu proyecto se añada a la cola en [Travis CI](http://travis-ci.org) y la contrucción de tu proyecto comenzará tan pronto como el worker de tu lenguaje esté disponible.
+Una vez configurado el Hook de GitHub, puedes hacer push a tu commit añadiendo el .travis.yml a tu repositorio. Esto hará que tu proyecto se añada a la cola en [Travis CI](http://travis-ci.org) y la contrucción de tu proyecto comenzará tan pronto como el worker de tu lenguaje esté disponible.
 
-Para ejecutar la construcción de tu proyecto puedes hacerlo de 2 maneras, puedes hacer un push a tu repositorio o bien, ir a los hooks de servicio en Github y usar el botón "Test Hook" para travis. Es importante destacar que **no es posible lanzar la primera construcción con el botón Test Hook de Github**. Es necesario que se haga un push en este caso. 
+Para ejecutar la construcción de tu proyecto puedes hacerlo de 2 maneras, puedes hacer un push a tu repositorio o bien, ir a los hooks de servicio en GitHub y usar el botón "Test Hook" para travis. Es importante destacar que **no es posible lanzar la primera construcción con el botón Test Hook de GitHub**. Es necesario que se haga un push en este caso. 
 
 ### Paso cinco: Ajustado la configuración
 

--- a/es/index.md
+++ b/es/index.md
@@ -3,7 +3,7 @@ title: Bienvenido a Travis CI
 layout: es
 ---
 
-Travis CI es un sistema de integración continua para la comunidad OpenSource. Está integrado con Github y ofrece soporte de primera clase para:
+Travis CI es un sistema de integración continua para la comunidad OpenSource. Está integrado con GitHub y ofrece soporte de primera clase para:
 
 * [Clojure](/docs/user/languages/clojure)
 * [Erlang](/docs/user/languages/erlang)

--- a/fr/docs/user/build-configuration.md
+++ b/fr/docs/user/build-configuration.md
@@ -4,9 +4,9 @@ layout: fr
 permalink: build-configuration/
 ---
 
-Le fichier `.travis.yml` vous permet de configurer vos builds. Travis CI va chercher le fichier `.travis.yml` dans le tree git pointé par le commit donné par Github.
+Le fichier `.travis.yml` vous permet de configurer vos builds. Travis CI va chercher le fichier `.travis.yml` dans le tree git pointé par le commit donné par GitHub.
 
-Une configuration donnée dans une branche ne va pas affecter la configuration du build d'une autre branche distincte. Notez que Travis CI va builder après <em>chaque</em> git push vers votre projet Github, quelque soit la branch, et même si le fichier `.travis.yml` n'est pas présent. Vous pouvez changer ce comportement avec des options de configuration.
+Une configuration donnée dans une branche ne va pas affecter la configuration du build d'une autre branche distincte. Notez que Travis CI va builder après <em>chaque</em> git push vers votre projet GitHub, quelque soit la branch, et même si le fichier `.travis.yml` n'est pas présent. Vous pouvez changer ce comportement avec des options de configuration.
 
 Par défaut, le worker utilise les commandes suivantes pour builder un projet :
 

--- a/fr/docs/user/getting-started.md
+++ b/fr/docs/user/getting-started.md
@@ -27,13 +27,13 @@ travis-ci.org est né début 2011 en tant que service pour la communauté Ruby e
 
 ### Etape n°1: S'authentifier
 
-Pour commencer à utiliser Travis CI, inscrivez-vous en utilisant Github OAuth. Allez sur [Travis CI](http://travis-ci.org) et suivez le lien.
+Pour commencer à utiliser Travis CI, inscrivez-vous en utilisant GitHub OAuth. Allez sur [Travis CI](http://travis-ci.org) et suivez le lien.
 
-Github vous demandera d'accorder les droits de lecture et écriture. Travis CI requière les droits d'écriture pour mettre en place les services hooks pour votre dépôt, mais n'affectera aucune autre partie
+GitHub vous demandera d'accorder les droits de lecture et écriture. Travis CI requière les droits d'écriture pour mettre en place les services hooks pour votre dépôt, mais n'affectera aucune autre partie
 
 ### Etape n°2: Activer les service hooks
 
-Une fois authentifié, allez sur votre [profil](http://travis-ci.org/profile). Vous retrouverez la liste de vos dépôt Github. Basculez sur "on" les dépôts que vous souhaitez lier à Travis CI. Allez ensuite sur la page service hooks Github de ce projet et entrez votre nom d'utilisateur Github et votre token Travis dans les paramètres du service Travis si ce n'est pas pré-rempli.
+Une fois authentifié, allez sur votre [profil](http://travis-ci.org/profile). Vous retrouverez la liste de vos dépôt GitHub. Basculez sur "on" les dépôts que vous souhaitez lier à Travis CI. Allez ensuite sur la page service hooks GitHub de ce projet et entrez votre nom d'utilisateur GitHub et votre token Travis dans les paramètres du service Travis si ce n'est pas pré-rempli.
 
 Si votre dépôt appartient à une organisation ou si basculer le bouton n'a pas suffit à mettre en place le hook, [faites le manuellement](/fr/docs/user/how-to-setup-and-trigger-the-hook-manually/) sur GitHub, cela ne prend pas plus que quelques minutes.
 

--- a/fr/docs/user/status-images.md
+++ b/fr/docs/user/status-images.md
@@ -4,7 +4,7 @@ layout: fr
 permalink: status-images/
 ---
 
-After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on Github or your project website.
+After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on GitHub or your project website.
 
 Your status button is available at the following URL:
 
@@ -33,7 +33,7 @@ Specify a `?branch=` parameter in the URI. Split branches with a comma if you wa
 
     http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png?branch=master,staging,production
 
-### Using SSL enabled status images on Github
+### Using SSL enabled status images on GitHub
 
 **Please note :** If you are placing this image on a GitHub project status page we recommend you use the SSL enabled url for the image so that GitHub does not proxy and cache it.
 

--- a/pt-BR/docs/dev/build_tasks.md
+++ b/pt-BR/docs/dev/build_tasks.md
@@ -16,7 +16,7 @@ The following classes encapsulate the application domain model concepts. I.e. th
 
 ### Request
 
-A Request is what external services, like currently Github, send to Travis Server. It contains the sent payload and has a one-to-one relationship to a Build.
+A Request is what external services, like currently GitHub, send to Travis Server. It contains the sent payload and has a one-to-one relationship to a Build.
 
 ### Build
 
@@ -82,7 +82,7 @@ When a build request comes in then a Request and a Build is created. The Build w
 
 The worker will pick up the Task::Configure and start working on it. It will send messages back to the application which will trigger state changes on the respective Task::Configure on the server side.
 
-If the Task::Configure errors then the containing Build will immediately go into the same state and stop proceeding. (At a later stage we might retry the errored task for particular reasons, like Github was down.)
+If the Task::Configure errors then the containing Build will immediately go into the same state and stop proceeding. (At a later stage we might retry the errored task for particular reasons, like GitHub was down.)
 
 Once the Task::Configure has finished and the build is approved then the Build will create and queue one or more Tasks according to the configuration (for starters these will be at least one Task::Test).
 
@@ -98,7 +98,7 @@ So, in more detail:
 
 ### Build creation
 
-* Github pings
+* GitHub pings
 * Server creates a Request
 * Server creates a Build with the Request
 * Server emits a build:created event

--- a/pt-BR/docs/user/build-configuration.md
+++ b/pt-BR/docs/user/build-configuration.md
@@ -120,7 +120,7 @@ This will include nested submodules (submodules of submodules), in case there ar
 
 ### Use Public URLs For Submodules
 
-If your project uses git submodules, make sure you use public git URLs. For example, for Github instead of
+If your project uses git submodules, make sure you use public git URLs. For example, for GitHub instead of
 
     git@github.com:someuser/somelibrary.git
 

--- a/pt-BR/docs/user/getting-started.md
+++ b/pt-BR/docs/user/getting-started.md
@@ -26,9 +26,9 @@ travis-ci.org originalmente começou como um serviço para a comunidade Ruby no 
 
 ### Primeiro passo: Login
 
-Para começar com o Travis CI, faça seu login com o Github OAuth. Vá até o [Travis CI](http://travis-ci.org) e clique no link de login no topo.
+Para começar com o Travis CI, faça seu login com o GitHub OAuth. Vá até o [Travis CI](http://travis-ci.org) e clique no link de login no topo.
 
-O Github vai pedir para você permitir acesso de leitura e escrita ao Travis. O Travis precisa de escrita para poder criar e configurar hooks de serviço para seus repositórios quando você pedir, ele não vai mexer em mais nada.
+O GitHub vai pedir para você permitir acesso de leitura e escrita ao Travis. O Travis precisa de escrita para poder criar e configurar hooks de serviço para seus repositórios quando você pedir, ele não vai mexer em mais nada.
 
 ### Segundo passo: Ativar o hook de serviço do GitHub
 

--- a/pt-BR/docs/user/status-images.md
+++ b/pt-BR/docs/user/status-images.md
@@ -12,7 +12,7 @@ We recommend you start with the [Getting Started](/docs/user/getting-started/) a
 
 ## Status Image URLs
 
-After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on Github or your project website.
+After adding your project to Travis, you can use the status buttons to show the current status of your projects in your `README` file on GitHub or your project website.
 
     https://secure.travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png
 


### PR DESCRIPTION
I noticed that **GitHub** was written as **Github** in several places in the documentation. This pull request fixes it.
