### PR TITLE
Update list of languages in /docs/

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -19,8 +19,11 @@ permalink: docs/
 
 ### Specific Language Help
 
+* [C](/docs/user/languages/c)
+* [C++](/docs/user/languages/cpp)
 * [Clojure](/docs/user/languages/clojure)
 * [Erlang](/docs/user/languages/erlang)
+* [Go](/docs/user/languages/go)
 * [Groovy](/docs/user/languages/groovy)
 * [Haskell](/docs/user/languages/haskell)
 * [Java](/docs/user/languages/java)


### PR DESCRIPTION
It was missing C, C++ and Go.
