### PR TITLE
Blog post on speeding up tests w/ build matrix.

### DIFF
--- a/blog/_posts/2012-11-28-speeding-up-your-tests.md
+++ b/blog/_posts/2012-11-28-speeding-up-your-tests.md
@@ -19,6 +19,8 @@ Travis’ [build
 matrix](http://about.travis-ci.org/docs/user/build-configuration/#The-Build-Matrix)
 feature.
 
+![](http://i.imgur.com/w8Wv1.jpg)
+
 Say you want to split up your unit tests and your integration tests into two
 different build jobs. They’ll run in parallel and fully utilize the available
 build capacity for your account.


### PR DESCRIPTION
A short post on using build matrices to speed up tests by having them run in parallel.
