### PR TITLE
reference GitHub Status Chrome Extension

### DIFF
--- a/docs/user/browser-extensions.md
+++ b/docs/user/browser-extensions.md
@@ -8,6 +8,8 @@ permalink: browser-extensions/
 
 [travis-ci.org Build Status Extension for Chrome](https://chrome.google.com/webstore/detail/klbmicjanlggbmanmpneloekhajhhbfb) displays the build status icon next to the project name on GitHub.
 
+[Universal Build Status Extenstion for Chrome](https://chrome.google.com/webstore/detail/github-status/mgbkbopoincdiimlleifbpfjfhcndahp) displays the latest build status from GitHub's statuses API next to the project name.
+
 ### Firefox
 
 [Travis CI Build Status Extension for Firefox](https://addons.mozilla.org/en-US/firefox/addon/githubtravis/) displays the build status icon next to the project name on GitHub.


### PR DESCRIPTION
I've [forked](https://github.com/excellenteasy/github-status) the existing Travis Chrome Extension so it works with the GitHub API, rather than just Travis-CI.

Referenced it in the docs.
