### PR TITLE
Add default IRC template to Notifications for reference

### DIFF
--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -95,6 +95,15 @@ You can interpolate the following variables:
 * *compare_url*: commit change view URL
 * *build_url*: URL of the build detail
 
+The default template is:
+
+    notifications:
+      irc:
+        template:
+          - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+          - "Change view : %{compare_url}"
+          - "Build details : %{build_url}"
+
 If you want the bot to use notices instead of regular messages the `use_notice` flag can be used:
 
     notifications:


### PR DESCRIPTION
Mention the current default template for the IRC notification; this was taken from `lib/travis/addons/irc/task.rb` at travis-ci/travis-core@5b64ce2d39a73eda757eb47d20862220a3076ada.
