### PR TITLE
Grammar fixes, alt text for images in blog posts

### DIFF
--- a/blog/_posts/2011-08-29-big_refactoring.md
+++ b/blog/_posts/2011-08-29-big_refactoring.md
@@ -20,9 +20,9 @@ summary is that our previous domain model still had the very basic design from
 its original spike. But here are some more details. We wanted to achieve the
 following things:
 
-* Split up the monster Build model into more finegrained classes for more
+* Split up the monster Build model into more fine-grained classes for more
   clarity
-* Move to a statemachine-like pattern for more explicitely reflecting
+* Move to a statemachine-like pattern for more explicitly reflecting
   various state changes that happen across various models
 * Lay better grounds for the long planned move to [AMQP](https://github.com/ruby-amqp/amqp)
   (communication with the workers)
@@ -50,7 +50,7 @@ added in a later stage.
 When we reviewed common Ruby statemachine implementations we found none of them
 do what we needed, so we came up with our own brand of it:
 [simple_states](https://github.com/svenfuchs/simple_states) may or may not
-useful for your own usecase but it does exactly what we need in Travis CI and
+useful for your own use case but it does exactly what we need in Travis CI and
 nothing more.
 
 Another gem that has been implemented in the course of this refactoring is
@@ -64,9 +64,9 @@ application, too (for `Travis.config`, specifically). We've used it in the
 [worker code](https://github.com/travis-ci/travis-worker) before and it worked
 pretty well.
 
-## In other news ...
+## In other news
 
-In other news, over the last month we have extract a [small project that we use to develop our Chef cookbooks](https://github.com/michaelklishin/sous-chef) and
+Over the last month we have extracted a [small project that we use to develop our Chef cookbooks](https://github.com/michaelklishin/sous-chef) and
 added the following tools to the [VM infrastructure](https://github.com/travis-ci/travis-cookbooks/tree/master/vagrant_base):
 
  * kerl to support Erlang with testing against multiple OTP releases

--- a/blog/_posts/2011-11-09-first_class_nodejs_support_on_travis_ci.md
+++ b/blog/_posts/2011-11-09-first_class_nodejs_support_on_travis_ci.md
@@ -41,7 +41,7 @@ Travis' Node.js builder will do the following as part of the build process:
  * Run `after_script` (can be more than one command)
  * Report the build has finished running
 
-Most of steps in the workflow can be overriden by projects that need it. We recommend you to use defaults when possible, though.
+Most of steps in the workflow can be overriden by projects that need it. We recommend you use defaults when possible though.
 
 For more information on what is [available in terms of services](http://about.travis-ci.org/docs/user/ci-environment/) (mysql, postgres, riak, etc.), or how to configure your builds or matrix, visit the [docs site](http://about.travis-ci.org/docs/).
 

--- a/blog/_posts/2011-11-13-first_class_php_support_on_travis_ci.md
+++ b/blog/_posts/2011-11-13-first_class_php_support_on_travis_ci.md
@@ -10,7 +10,7 @@ Today we are happy to announce first class PHP support with Travis CI.
 It includes all the same features Ruby, Erlang and Node.js projects enjoy today, including:
 
  * Easy to get started and integrates with GitHub.
- * Test against multiple databases and services, including Mysql, Postgres, Redis, RabbitMQ and many more.
+ * Test against multiple databases and services, including MySQL, Postgres, Redis, RabbitMQ and many more.
  * Test your projects against multiple PHP versions.
  * Build results are publicly available online so you can link to them in your bug reports, including line numbers.
  * Notifications the way you want them! (email, IRC, and webhooks)
@@ -25,8 +25,7 @@ Having all those projects building fine for several days makes us confident that
 
 Please see our [initial documentation for PHP projects](http://about.travis-ci.org/docs/user/languages/php) and [the rest of the guides](http://about.travis-ci.org/docs/). We tried to link to as many real world .travis.yml examples to demonstrate all the features in action.
 
-In addition, we have a couple of machines lined up that we will be running PHP builds on. One of them is [Shopify](http://shopify.com): they donated us a worker we have been using for Node.js projects. Another one is [ServerGrove](http://servergrove.com), experts in PHP hosting and specifically frameworks like Symfony and Zend Framework: they donated us one more machine to run PHP builds
-on.
+In addition, we have a couple of machines lined up that we will be running PHP builds on. One of them is [Shopify](http://shopify.com): they donated a worker we have been using for Node.js projects. Another one is [ServerGrove](http://servergrove.com), experts in PHP hosting and specifically frameworks like Symfony and Zend Framework: they donated us one more machine to run PHP builds on.
 
 If you have questions, find us in #travis on irc.freenode.net, we will be happy to answer them. To stay up to date with new announcements, CI environment software updates and more, [follow us on Twitter](https://twitter.com/travisci) and [join our mailing list](https://groups.google.com/forum/#!forum/travis-ci).
 

--- a/blog/_posts/2012-02-21-announcing_support_for_java_scala_and_groovy_on_travis_ci.md
+++ b/blog/_posts/2012-02-21-announcing_support_for_java_scala_and_groovy_on_travis_ci.md
@@ -17,7 +17,7 @@ The JVM ecosystem is very vibrant with multiple exciting languages maturing and 
 
 You can watch build logs in near-real time in your browser, access logs later, and even link to log line numbers (for example, when reporting an issue).
 
-Thanks to Github integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
+Thanks to GitHub integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
 
 Started in early 2011, Travis CI has since run half a million builds for over 6,000 open source projects, including Ruby, Ruby on Rails, RubyGems, Node.js, Leiningen, Symfony and many more.
 
@@ -26,7 +26,7 @@ Started in early 2011, Travis CI has since run half a million builds for over 6,
 ## Getting Your Project on travis-ci.org
 
 Travis CI currently provides OpenJDK 6, Maven 3, SBT 0.11.x and Gradle (currently 1.0 Milestone 8). To get started, you need to add one file
-(.travis.yml) and the Github hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). If your
+(.travis.yml) and the GitHub hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). If your
 project uses Maven or Gradle, a minimal .travis.yml would look like this:
 
     language: java
@@ -72,7 +72,7 @@ Note that Clojure and Scala build tools allow testing against multiple versions 
 
 ### Learn more
 
-To learn what tools and services (mysql, postgres, riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
+To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
 If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 

--- a/blog/_posts/2012-02-27-announcing_python_and_perl_support_on_travis_ci.md
+++ b/blog/_posts/2012-02-27-announcing_python_and_perl_support_on_travis_ci.md
@@ -9,11 +9,11 @@ Just shy of a week ago we announced support for Java, Scala, and Groovy. Well, w
 
 Today we are happy to announce first class support for Python and Perl projects!
 
-Adding support for Perl and Python was a no brainer for us, not that it was easy, because it wasn't, but that both languages were sought after by their respective communities and complete the quest for the three P's (PHP, Perl, and Python).
+Adding support for Perl and Python was a no brainer for us, not that it was easy, because it wasn't, but that both languages were sought after by their respective communities and completes the quest for the three P's (PHP, Perl, and Python).
 
-Perl, which has been around since 1987 (Genesis ["Land Of Confusion"](http://www.youtube.com/watch?v=1pkVLqSaahk))and has a toolset just as strong and mature as its community. For example, the Perl community has had a variation of Travis for the last 10 years called CPANTesters, with the difference being that CPANTesters tests releases while we test active development.
+Perl, which has been around since 1987 (Genesis ["Land Of Confusion"](http://www.youtube.com/watch?v=1pkVLqSaahk)) and has a toolset just as strong and mature as its community. For example, the Perl community has had a variation of Travis for the last 10 years called CPANTesters, with the difference being that CPANTesters tests releases while we test active development.
 
-Python, around since the early 90's (think MC Hammer ["Too Legit to Quit"](http://youtu.be/_UJaLq4YOo0), 1991), and in fact it's OLDER than Java! It is used for pretty much EVERYTHING you can think of, from research at CERN, to build website (YouTube and DISQUS), scripting for Games (Battlefield 2), and scripting for Graphics programs (Autodesk Maya, GIMP, Panda3D and Blender to name a few). Pretty much, you have used Python and you didn't even know it!
+Python, around since the early 90's (think MC Hammer ["Too Legit to Quit"](http://youtu.be/_UJaLq4YOo0), 1991), and in fact it's OLDER than Java! It is used for pretty much EVERYTHING you can think of, from research at CERN, building websites (YouTube and DISQUS), scripting for Games (Battlefield 2), and scripting for Graphics programs (Autodesk Maya, GIMP, Panda3D and Blender to name a few). You may have used Python and didn't even know it!
 
 ## Wait, What Is Travis CI Anyway?
 
@@ -21,7 +21,7 @@ Python, around since the early 90's (think MC Hammer ["Too Legit to Quit"](http:
 
 You can watch build logs in near-real time in your browser, access logs later, and even link to log line numbers (for example, when reporting an issue).
 
-Thanks to Github integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
+Thanks to GitHub integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
 
 Started in early 2011, Travis CI has since run half a million builds for over 6,000 open source projects, including Ruby, Ruby on Rails, RubyGems, Node.js, Leiningen, Symfony and many more.
 
@@ -29,7 +29,7 @@ Started in early 2011, Travis CI has since run half a million builds for over 6,
 ## Getting Your Python Project on Travis CI
 
 Travis CI provides multiple Python and Perl versions to test against. To get started, you need to add one file
-(.travis.yml) and the Github hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). A minimal .travis.yml
+(.travis.yml) and the GitHub hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). A minimal .travis.yml
 would look like this:
 
     language: python
@@ -49,7 +49,7 @@ It is possible to add new commands to the build lifecycle, please refer to [our 
 ## Getting Your Perl Project on Travis CI
 
 Travis CI provides three Perl versions to test against. To get started, you need to add one file
-(.travis.yml) and the Github hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). A minimal .travis.yml
+(.travis.yml) and the GitHub hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). A minimal .travis.yml
 would look like this:
 
     language: perl
@@ -91,7 +91,7 @@ Travis' build workflow usually is
 
 ### Learn more
 
-To learn what tools and services (mysql, postgres, riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
+To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
 If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 

--- a/blog/_posts/2012-03-11-announcing_haskell_support_on_travis_ci.md
+++ b/blog/_posts/2012-03-11-announcing_haskell_support_on_travis_ci.md
@@ -24,7 +24,7 @@ Travis' Eleven.
 
 You can watch build logs in near-real time in your browser, access logs later, and even link to log line numbers (for example, when reporting an issue).
 
-Thanks to Github integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
+Thanks to GitHub integration, Travis CI lets your contributors effortlessly add their development forks to test work-in-progress branches and makes your CI status very visible to the community thanks to our [CI badges](http://about.travis-ci.org/docs/user/status-images/).
 
 Started in early 2011, Travis CI has since run half a million builds for over 7,000 open source projects, including Ruby, Ruby on Rails, RubyGems, Node.js, Leiningen, Symfony and many more.
 
@@ -33,7 +33,7 @@ Started in early 2011, Travis CI has since run half a million builds for over 7,
 ## Getting Your Project on Travis CI
 
 Travis CI currently provides [Haskell Platform](http://hackage.haskell.org/platform/contents.html) 2011.04 (with GHC 7, Cabal, Happy, Alex and so on). To get started, you need to add one file
-(.travis.yml) and the Github hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). If your
+(.travis.yml) and the GitHub hook as described in the [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/). If your
 project uses Cabal, a minimal .travis.yml would look like this:
 
     language: haskell
@@ -65,7 +65,7 @@ By default Travis' build workflow is
 
 ### Learn more
 
-To learn what tools and services (mysql, postgres, riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
+To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
 If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 

--- a/blog/_posts/2012-03-27-upcoming_ubuntu_11_10_migration.md
+++ b/blog/_posts/2012-03-27-upcoming_ubuntu_11_10_migration.md
@@ -45,7 +45,7 @@ One of the biggest changes with every distro release is GCC version changes. 11.
 ### OpenSSL
 
 Another important change OpenSSL version. 11.10 ships with OpenSSL 1.0 by default, but even more importantly,
-disables SSLv2 support. SSLv2 is very old (released in [1995](http://youtu.be/N6voHeEa3ig)), there were 4 updates to the spec after it: SSL 3.0, TLS 1.0, TLS 1.1 and TLS 1.2. In addition to that, SSLv2 contains several known [security flaws](http://en.wikipedia.org/wiki/Secure_Socket_Layer#cite_note-5)
+disables SSLv2 support. SSLv2 is very old (released in [1995](http://www.youtube.com/watch?v=N6voHeEa3ig)), there were four updates to the spec after it: SSL 3.0, TLS 1.0, TLS 1.1 and TLS 1.2. In addition to that, SSLv2 contains several known [security flaws](http://en.wikipedia.org/wiki/Secure_Socket_Layer#cite_note-5)
 and all new distributions either already dropped support for it or will be dropping it very soon.
 
 

--- a/blog/_posts/2012-04-02-monitoring-metrics-infratructure-oh-my.md
+++ b/blog/_posts/2012-04-02-monitoring-metrics-infratructure-oh-my.md
@@ -13,7 +13,7 @@ piece to make sure they do their job. Obviously there's no need to keep this a
 secret, so let's talk about some recent changes to Travis' infrastructure.
 
 Case in point. A recent deployment broke updating profiles temporarily. Here's a
-pretty graph showing the pretty much exact point in time when we deployed and
+pretty graph showing pretty much the exact point in time when we deployed and
 the spike in the number of errors.
 
 ![Pretty graph showing deployments](http://s3itch.paperplanes.de/Librato_Metrics-20120402-114010.png)
@@ -24,7 +24,7 @@ There's still some noise though, still several 500 errors popping up in our
 logs. It took a while to fix those, but you can see it eventually ebbed off
 after another deployment.
 
-This is a pretty powerful tool. We added putting more and more metrics on the
+This is a pretty powerful tool. We added more and more metrics on the
 moving parts in Travis. If you want to know why, you should read this [blog
 post](http://code.flickr.com/blog/2008/10/27/counting-timing/) from the Flickr
 engineering team, and you should definitely watch [Coda Hale's talk Metrics,
@@ -53,7 +53,7 @@ library that turns Rails' logging events into a neat, single line per request.
 You can read all about it in [Mathias' blog
 post](http://www.paperplanes.de/2012/3/14/on-notifications-logsubscribers-and-bringing-sanity-to-rails-logging.html).
 
-This helped streamlining our logging, making it more and more useful along the
+This helped streamline our logging, making it more and more useful along the
 way. All our logs are aggregated in [Papertrail](https://papertrailapp.com/),
 who were also kind enough to offer sponsoring their services for Travis.
 
@@ -89,9 +89,9 @@ graphed in Librato's Metrics. It's pretty awesome. Every bug fixed is a new
 opportunity to add more graphs and add more logging.
 
 For good measure, here's another graph showing the requests we're receiving from
-Github. It includes the received, accepted and rejected pushes.
+GitHub. It includes the received, accepted and rejected pushes.
 
-![Github Requests](http://s3itch.paperplanes.de/Skitch-20120402-202853.png)
+![GitHub Requests](http://s3itch.paperplanes.de/Skitch-20120402-202853.png)
 
 The beautiful bit is that we can take any metric and correlate it with others.
 That's a pretty powerful tool to find problems in infrastructure.

--- a/blog/_posts/2012-05-02-announcing-pull-request-support.md
+++ b/blog/_posts/2012-05-02-announcing-pull-request-support.md
@@ -23,7 +23,7 @@ I'm pretty excited about this one, as I've been working on it over the last week
   <figcaption>A typical Pull Request</figcaption>
 </figure>
 
-When Github first announced [Pull Requests 2.0](https://github.com/blog/712-pull-requests-2-0), it wasn't obvious right away how truly amazing this feature is for us developers.
+When GitHub first announced [Pull Requests 2.0](https://github.com/blog/712-pull-requests-2-0), it wasn't obvious right away how truly amazing this feature is for us developers.
 
 <figure class="small right">
   [ ![Pull Request 2.0 Workflow](http://travis-pr.herokuapp.com/image/slides/pre-merge-button.png) ](http://travis-pr.herokuapp.com/image/slides/pre-merge-button.png)
@@ -39,8 +39,8 @@ It really only had one downside: Merging still was as complicated as before. You
 ## The Merge Button
 
 <figure>
-  [ ![GitHub's Merge Button allows merging Pull Request form the Web Interface](http://travis-pr.herokuapp.com/image/slides/merge_button.png) ](http://travis-pr.herokuapp.com/image/slides/merge_button.png)
-  <figcaption>GitHub's Merge Button allows merging Pull Request form the Web Interface</figcaption>
+  [ ![GitHub's Merge Button allows merging Pull Request from the web interface](http://travis-pr.herokuapp.com/image/slides/merge_button.png) ](http://travis-pr.herokuapp.com/image/slides/merge_button.png)
+  <figcaption>GitHub's Merge Button allows merging Pull Request from the web interface</figcaption>
 </figure>
 
 GitHub, once more, came to our rescue by adding the [Merge Button](https://github.com/blog/843-the-merge-button).
@@ -54,7 +54,7 @@ By pressing a button on the website, one could easily merge Pull Requests withou
 
 This feature, combined with the [Fork and Edit](https://github.com/blog/844-forking-with-the-edit-button) button, made contributing a no brainer.
 
-Especially the roundtrip time for documentation fixes, like typos, broken examples, etc. went down to sometimes just a few seconds.
+Especially the round-trip time for documentation fixes, like typos, broken examples, etc. went down to sometimes just a few seconds.
 
 Contributing a fix became as simple as two clicks on GitHub. Making contributions that easy lowers the barrier and thereby strengthens the Open Source ecosystem.
 
@@ -67,7 +67,7 @@ You probably can tell by now how much we love this feature.
 
 There is a downside, though. The Merge Button is not really usable for anything but documentation.
 
-If you click the Merge Button for anything touching code, you risk breaking upstream. Maybe this seem acceptable at first, after all your CI will tell you if you broke anything. You are using CI, right?
+If you click the Merge Button for anything touching code, you risk breaking upstream. Maybe this seems acceptable at first, after all your CI will tell you if you broke anything. You are using CI, right?
 
 However, it not only renders your mainline pretty unstable, it also changes responsibility. All of a sudden you as a maintainer are responsible for fixing the issue, if only by reverting the commits.
 
@@ -84,7 +84,7 @@ It would be really cool to just know if the Pull Request breaks anything, withou
 
 This is basically what we've implemented. We test every mergeable Pull Request and have our friendly [Travisbot](https://github.com/travisbot) leave a comment in the Pull Request discussion.
 
-That way you can now safely press the Merge Button. That is, if it doesn't break anything, of course. And if it breaks, it's not necessarily the maintainers (or worse, the users) responsibility to deal with the issue.
+That way you can now safely press the Merge Button. That is, if it doesn't break anything, of course. And if it breaks, it's not necessarily the maintainers' (or worse, the users') responsibility to deal with the issue.
 
 Or imagine having a broken upstream and someone submits a Pull Request fixing it.
 
@@ -95,7 +95,7 @@ Or imagine having a broken upstream and someone submits a Pull Request fixing it
 
 In contrast to most [self-made solutions](https://github.com/cramerdev/jenkins-comments) out there, we actually test the *merged* version, rather than just the fork or feature branch. Thus, we also take into account changes made upstream *after* the repository has been forked.
 
-We will also re-run the tests whenever new commits are added to a Pull Requests (yes, this works fine with force pushes and rebases). Also, it pretty much works with anything that is mergeable, might it be a branch, tag, fork, etc. As long as you see the green Merge Button, we can test it.
+We will also re-run the tests whenever new commits are added to Pull Requests (yes, this works fine with force pushes and rebases). Also, it pretty much works with anything that is mergeable, might it be a branch, tag, fork, etc. As long as you see the green Merge Button, we can test it.
 
 ## Are we there yet?
 
@@ -112,8 +112,8 @@ If you made it this far in the blog post, you probably want it for your reposito
   <figcaption>Let us know if you want this feature</figcaption>
 </figure>
 
-As we are still improving it, and are not sure if we can stand the load of activating it for everyone right away, we are turning it on on a repo per repo basis.
+As we are still improving it, and are not sure if we can stand the load of activating it for everyone right away, we are turning it on on a repo by repo basis.
 
-Please note that we start unrolling for those people, that donated, so I was actually able to work on this. So, if you donated and want this, just [let us know](mailto:contact+pr@travis-ci.org?subject=Pull Request Support&body=Could you please activate PR testing for USER/REPO? I donated - Order #XYZ - and would love to use this feature. XOXO - NAME).
+Please note that we started unrolling for those who donated, so I was actually able to work on this. So, if you donated and want this, just [let us know](mailto:contact+pr@travis-ci.org?subject=Pull Request Support&body=Could you please activate PR testing for USER/REPO? I donated - Order #XYZ - and would love to use this feature. XOXO - NAME).
 
 If you didn't donate, but still want to use this feature right away, our [Love Campaign](https://love.travis-ci.org/) is still running.

--- a/blog/_posts/2012-05-22-thank-you-for-the-awesome-support.md
+++ b/blog/_posts/2012-05-22-thank-you-for-the-awesome-support.md
@@ -48,8 +48,7 @@ All this swag is in the mail right now, and for lots of Europe and America it sh
 In fact, if you want some swag or your own Love Certificate it isn't too late to [donate](http://love.travis-ci.org)! ;)
 
 
-What we have delivered so far
------------------------------
+### What we have delivered so far
 
 <figure class="small right">
   [ !["Dear @kanbanery @wooga. These two thank you for the @travisci support." - John E. Vincent](https://twitpic.com/show/large/9mjmhh) ](https://twitter.com/#!/lusis/status/203624917055455235)
@@ -60,7 +59,7 @@ What we have delivered so far
 Apart from sending out swag we also promised to add some awesome new features to Travis. These included:
 
 * Support for more languages
-* Pre-tested pull-requests
+* Pre-tested pull requests
 * Private build support
 * Build artifacts
 
@@ -71,15 +70,13 @@ So far we have delivered the first two of these. With the help of the community 
   <figcaption>Loads of swag</figcaption>
 </figure>
 
-Also, we have implemented support for [pre-tested pull-requests](http://about.travis-ci.org/blog/announcing-pull-request-support/), which has taken the community by storm. We are currently still unlocking accounts for donors before we will finally release the feature into the wild. So, if you would like to use it for your projects please shoot us an email.
+Also, we have implemented support for [pre-tested pull requests](http://about.travis-ci.org/blog/announcing-pull-request-support/), which has taken the community by storm. We are currently still unlocking accounts for donors before we will finally release the feature into the wild. So, if you would like to use it for your projects please shoot us an email.
 
 We are also in the middle of completing private build support, which will be released as a product currently codenamed "Travis Pro - Magnum". We have had a few handpicked users running builds on a alpha-stage system for quite a while, but we still need to put more work into it before we can add more users.
 
 Expect a blog post next week with further details on what is going on with Pro, including how you can test drive it for yourself.
 
-
-But we have some special news for you....
------------------------------------------
+### But we have some special news for you....
 
 We are very pleased to announce that we are adding some goodies to each of the plans.
 
@@ -103,8 +100,7 @@ These new plans will take effect immediately, and over the coming weeks we will 
 If you would like to upgrade your donation to one of the bigger plans, email [contact@travis-ci.org](mailto:contact@travis-ci.org) and we can help you with it.
 
 
-Last but not least
-------------------
+### Last but not least
 
 We would like to extend a massive amount of love and thanks to RailsCasts, Pragmatic Programmer, and Mathias for being so awesome and generous.
 
@@ -129,7 +125,7 @@ The Travis Team
 * 28 company donations
 * Over 5,000 pieces of swag sent out
 * Over 1,000 EUR in postage and envelopes to send all the swag
-* And so far only 1 envelope has been 'return to sender'
+* And so far only one envelope has been 'return to sender'
 
 <figure>
   [ !["Ma, see what the mailman brought :)" - Dennis Reimann](https://p.twimg.com/AssRaPZCIAEAOr0.jpg:large) ](https://twitter.com/#!/dennisreimann/status/201273750849724416)

--- a/blog/_posts/2012-06-05-support_for_multiple_jdks.md
+++ b/blog/_posts/2012-06-05-support_for_multiple_jdks.md
@@ -9,9 +9,9 @@ twitter: michaelklishin
 
 Every new feature starts with a developer wanting to scratch an itch.
 
-When Travis CI started in early 2011, one of the goals behind it was to make CI for everyone, including ourselves. Back then the Ruby community was in full swing moving to Ruby 1.9, and most popular projects supported 1.9 unknowingly, but it was common to run into issues with projects that either did not test against 1.9, or tested against 1.9 but not 1.8. So one of the features that was added very early on was ability to easily test against multiple versions and implementations of Ruby in the simplest way possible.
+When Travis CI started in early 2011, one of the goals behind it was to make CI for everyone, including ourselves. Back then the Ruby community was in full swing moving to Ruby 1.9, and most popular projects supported 1.9 unknowingly, but it was common to run into issues with projects that either did not test against 1.9, or tested against 1.9 but not 1.8. So one of the features that was added very early on was the ability to easily test against multiple versions and implementations of Ruby in the simplest way possible.
 
-Fast forward to around August 2011. We were working on the Erlang support, the first additional language to be added to Travis, and had a question to face: should multi-runtime support be a Ruby-specific feature or should we try to do the same for more languages if we can? It was a no brainer: easy CI against multiple runtimes is too awesome a feature to pass by. So we launched Erlang support with multiple Erlang/OTP versions from the start.
+Fast forward to around August 2011. We were working on Erlang support, the first additional language to be added to Travis, and had a question to face: should multi-runtime support be a Ruby-specific feature or should we try to do the same for more languages if we can? It was a no brainer: easy CI against multiple runtimes is too awesome a feature to pass by. So we launched Erlang support with multiple Erlang/OTP versions from the start.
 
 Today you can test your projects in several languages against multiple releases or implementations. Sometimes we did not have to do any work to make this happen: Clojure and Scala build tools, ([Leiningen](http://leiningen.org) and SBT, respectively), for example, let you test against multiple versions without having to install several versions of Clojure or Scala.
 
@@ -35,7 +35,7 @@ To test against multiple JDKs, list them using the `:jdk` key in your `.travis.y
 
 It is that simple and that easy!
 
-You can specify one, two or all jdk keys, and it works the same way for Java, Clojure and so on.
+You can specify one, two or all JDK keys, and it works the same way for Java, Clojure and so on.
 
 Here are some real examples:
 

--- a/blog/_posts/2012-07-25-go_c_and_cpp_support.md
+++ b/blog/_posts/2012-07-25-go_c_and_cpp_support.md
@@ -10,7 +10,7 @@ twitter: michaelklishin
 Travis CI was designed to be an awesome testing service for anyone and everyone. With over 16,000 projects
 on Travis to date, it is not uncommon to see people pushing the boundaries and building projects Travis CI does not have native support for.
 
-Over time we notice that some languages gain enough traction on Travis that it makes sense to provide some sugar so that configuration and setup becomes as simple as counting to three. From fairly early on
+Over time we noticed that some languages gain enough traction on Travis that it makes sense to provide some sugar so that configuration and setup becomes as simple as counting to three. From fairly early on
 we've seen C and C++ projects being built and tested on Travis, as well as a surge of Go projects as of late. 
 
 Today we are happy to announce first class support for C, C++ and Go projects.

--- a/blog/_posts/2012-09-04-pull-requests-just-got-even-more-awesome.md
+++ b/blog/_posts/2012-09-04-pull-requests-just-got-even-more-awesome.md
@@ -13,7 +13,7 @@ everyone](http://about.travis-ci.org/blog/pull-request-testing-for-everyone/)
 and all of their projects by default.
 
 Since then, [travisbot](https://github.com/travisbot) has been busy, very busy,
-leaving comments on your pull requests, helping you in making a fair judgement
+leaving comments on your pull requests, helping you make a fair judgement
 of whether a pull request is good to merge or not. We have built more than 17000
 pull requests since we launched this feature. We salute you, travisbot, for
 never letting us down!
@@ -39,7 +39,7 @@ see the changes happen as if done by the magic robot hands of travisbot himself!
 ![Pending pull request](http://s3itch.paperplanes.de/Fullscreen-14-3-20120827-214334.png)
 
 Should a pull request fail the build, as unlikely as it may seem, you'll see a
-warning that warns you about merging this pull request. This is true for a
+warning about merging this pull request. This is true for a
 pending build as well. They're both marked as unstable. You can merge it, but
 you do so at your own risk. After all, isn't it nicer to just wait patiently for
 that beautiful green to come up? We thought so!
@@ -60,7 +60,7 @@ ship features.
 Let's have a look at what Josh has been up to in this pull request. Notice the
 little bubbles next to each commit reference.
 
-![Josh](http://s3itch.paperplanes.de/joshk-20120827-215347.png)
+![pull request with commits from Josh](http://s3itch.paperplanes.de/joshk-20120827-215347.png)
 
 Want to have a look at what it looks like for real? No worries, here's a [pull
 request](https://github.com/rspec/rspec-core/pull/666) on the rspec project,

--- a/blog/_posts/2012-09-05-on-yesterdays-log-unavailability.md
+++ b/blog/_posts/2012-09-05-on-yesterdays-log-unavailability.md
@@ -34,7 +34,7 @@ hour.
 Here's a graph outlining what happened in the log processing and how things
 evolved when we finally found and fixed the issue:
 
-![](http://s3itch.paperplanes.de/Metric_%E2%80%93_Librato_Metrics-20120906-130435.png)
+![log processing graph](http://s3itch.paperplanes.de/Metric_%E2%80%93_Librato_Metrics-20120906-130435.png)
 
 For most of the day, processing got stuck at around 700 messages per minute.
 Given that we get a few hundred more than that every minute, backed-up queues
@@ -63,7 +63,7 @@ jobs with a lot of log output can still clog up a single processor thread's
 queue.
 
 We weren't sure if this would affect our database load at all, but luckily, even
-with 9 threads, there was no noteworthy increase in database response time.
+with nine threads, there was no noteworthy increase in database response time.
 Thanks to our graphs in [Librato Metrics](http://metrics.librato.com), we could
 keep a close eye on any variance in the mean and 95th percentile.
 
@@ -71,11 +71,11 @@ keep a close eye on any variance in the mean and 95th percentile.
 
 We've been thinking a lot about how we can improve the processing of logs in
 general. Currently, the entire log is stored in one field in the database,
-constantly being updated. That has the downside, that on every update, the
-column has to be read to be updated again, in the worst case.
+constantly being updated. The downside is that on every update, in the worst 
+case, the column has to be read to be updated again.
 
 To avoid that, we'll be splitting up the logs into chunks and store only these
-chunks. Every messages gets timestamped and a chunk identifier based on the
+chunks. Every message gets timestamped and a chunk identifier based on the
 position in the log. Based on that information, we can reassemble the logs
 from all chunks to display in the user interface while the build is running.
 

--- a/blog/_posts/2012-09-13-an-update-on-the-sites-availability.md
+++ b/blog/_posts/2012-09-13-an-update-on-the-sites-availability.md
@@ -7,7 +7,7 @@ permalink: blog/2012-09-13-an-update-on-the-sites-availability
 layout: post
 ---
 As I'm sure you've noticed, Travis CI wasn't doing its best recently. The site
-kept being unavailable in unregular intervals. We're sorry for these
+kept being unavailable at irregular intervals. We're sorry for these
 unavailabilities, and we wanted to keep you in the loop of what has happened and
 what we've done about it. Or rather, what we're still doing about it.
 

--- a/blog/_posts/2012-09-27-hipchat-notifications.md
+++ b/blog/_posts/2012-09-27-hipchat-notifications.md
@@ -8,8 +8,8 @@ permalink: blog/2012-09-27-hipchat-notifications
 ---
 Deep in the bowels of the [Travis code
 base](https://github.com/travis-ci/travis-core/blob/master/lib/travis/task/hipchat.rb),
-it remained hidden for two months before we finally bring it up to the light and
-write a blog post about it: HipChat build notifications!
+it remained hidden for two months before we finally decided to bring it up to the light 
+and write a blog post about it: HipChat build notifications!
 
 <img width="570" src="http://s3itch.paperplanes.de/skitched-20120927-102551.png"/>
 
@@ -19,7 +19,7 @@ Just add the following line to your `.travis.yml`, and Bob's your uncle:
       hipchat: [api token]@[room name]
 
 HipChat has something nice going for it: you can set the background of a
-particular message, so we set the background to green or red depending on
+particular message. So we can set the background to green or red depending on
 the build status. Neat!
 
 Needless to say, this feature is available on both Travis platforms, [open

--- a/blog/_posts/2012-09-29-ssl.md
+++ b/blog/_posts/2012-09-29-ssl.md
@@ -13,7 +13,7 @@ Note that we are now using the same certificate for *secure.travis-ci.org*, so y
 
 ### Why didn't we have that before?
 
-Most of the content we serve is publicly available, the Github scope we use does not even allow us to access private data. This is of course different for [Travis Pro](http://travis-ci.com), which is why we have been using full SSL encryption there from day one.
+Most of the content we serve is publicly available, the GitHub scope we use does not even allow us to access private data. This is of course different for [Travis Pro](http://travis-ci.com), which is why we have been using full SSL encryption there from day one.
 
 ### Why did we turn it on?
 
@@ -39,7 +39,7 @@ We, for instance, currently have 30 apps on Heroku and instead of having 30 SSL 
 
 ### The future is secure
 
-We will continue to improve security here at Travis CI. In fact, we are currently working on a new architecture for our web front-end, featuring a new [JavaScript client](https://github.com/travis-ci/travis-ember) and a new [JSON API](https://github.com/travis-ci/travis-api).
+We will continue to improve security here at Travis CI. In fact, we are currently working on new architecture for our web front-end, featuring a new [JavaScript client](https://github.com/travis-ci/travis-ember) and a new [JSON API](https://github.com/travis-ci/travis-api).
 
 Instead of just trying to detect opportunistic attacks, it will also features a stateless, session-free architecture. This instantly renders it invulnerable against a whole range of attacks all based on session capturing, like normal CSRF attacks or even [CRIME](http://arstechnica.com/security/2012/09/many-ways-to-break-ssl-with-crime-attacks-experts-warn/).
 

--- a/blog/_posts/2012-10-23-introducing-travis-cis-next-generation-web-client.md
+++ b/blog/_posts/2012-10-23-introducing-travis-cis-next-generation-web-client.md
@@ -22,7 +22,7 @@ People just love it:
 quite well over time.
 
 At the same time we are all aware of the issues that our client had over the
-last months, especially since traffic on Travis CI has exploded.
+last few months, especially since traffic on Travis CI has exploded.
 
 We are now running about 10,000 builds a day for nearly 25,000 repositories and
 our old client could just not hold up with that. Especially in situations where
@@ -30,7 +30,7 @@ our queues had run full and other, seemingly "unrelated" issues occured and the
 whole client just stalled on Chrome.
 
 On top of the scalability issues our codebase made it pretty hard to fix things
-and add new features. Instead one had to fight with really old library versions
+and add new features. Instead, one had to fight with really old library versions
 that could not be upgraded easily, a ton of work-arounds and even things like a
 slow asset compilation pipeline.
 
@@ -38,15 +38,15 @@ Even though the client as such was still great, people became increasingly
 unhappy with the issues it started to show. And rightfully so. We felt just
 the same!
 
-So today we&rsquo;re really happy to announce Travis CI&rsquo;s next generation
+So today we're really happy to announce Travis CI's next generation
 web client.
 
 
 ## The next generation web client
 
 The new Travis CI web client is a complete reimplementation of the proven
-feature set of the last version. Development started [4 months ago](https://github.com/travis-ci/travis-web/commit/a3f629bd0d54c99450fb41e366c78f4e8f1a7783)
-and a huge amount of work has been put into it over the last months.
+feature set of the last version. Development started [four months ago](https://github.com/travis-ci/travis-web/commit/a3f629bd0d54c99450fb41e366c78f4e8f1a7783)
+and a huge amount of work has been put into it over the last few months.
 
 It is currently running on
 [https://next.travis-ci.org](https://next.travis-ci.org) and we will keep the
@@ -56,7 +56,7 @@ hashed out.
 
 ### New features
 
-With this new version  our main goal was to reimplement the same, well known
+With this new version our main goal was to reimplement the same, well known
 and battle tested functionality that the old client had, but make it based
 on the latest versions of ember and ember-data, improve its performance,
 overall stability and usability.
@@ -73,11 +73,11 @@ We have never been very religious about this but there always were good
 arguments that made us want to move away from the hashbang URLs that Travis CI
 has started with (and frankly, worked great despite using them).
 
-With the move to the new, shiny Ember router and the new api endpoint there
+With the move to the new, shiny Ember router and the new API endpoint there
 was no reason to stick with them and we changed our URL scheme to plain,
 simple (and some would say "non-broken") URLs:
 
-![](http://s3itch.svenfuchs.com/no_hashbang_urls-20121017-001420.jpg)
+![URL scheme in location bar](http://s3itch.svenfuchs.com/no_hashbang_urls-20121017-001420.jpg)
 
 #### Requeue builds button
 
@@ -107,7 +107,7 @@ to use. We have now tweaked font sizes, widths and margins and made good use of
 css media queries to respond to different screen sizes gracefully.
 
 Even though this can still be improved (especially for very small screens, we
-will happily accept pull requests) we believe it&rsquo;s a huge improvement:
+will happily accept pull requests) we believe it's a huge improvement:
 
 ![](http://s3itch.svenfuchs.com/left-sidebar-scaling-20121017-001639.jpg)
 
@@ -117,7 +117,7 @@ The profile page (now renamed to "Accounts") got a complete overhaul:
 
 ![](http://s3itch.svenfuchs.com/account-hooks-20121017-001727.jpg)
 
-If you&rsquo;re into CSS then you might notice that the service hooks on/off
+If you're into CSS then you might notice that the service hooks on/off
 switch is done entirely in CSS without using any images.
 
 The somewhat weird behaving and flickering feature that displayed repository
@@ -126,14 +126,14 @@ replaced by an "Info" button which reveals all repository descriptions:
 
 ![](http://s3itch.svenfuchs.com/repo-info-20121017-004218.jpg)
 
-Also, we have ressurected the long buried selection indicator for the
+We have also ressurected the long buried selection indicator for the
 repository list on the left as well as the accounts list on your profile page.
 And one can now expand and collapse all workers in the right sidebar with one
 click:
 
 ![](http://s3itch.svenfuchs.com/list-indicator-expand-workers-20121017-001806.jpg)
 
-And finally there&rsquo;s a more generic way to display popups:
+And finally there's a more generic way to display popups:
 
 ![](http://s3itch.svenfuchs.com/popup-20121017-001956.jpg)
 
@@ -170,9 +170,4 @@ of the Ember.js core team, most importantly
 [Adam Hawkins](https://github.com/twinturbo) who helped us come up with a
 solid and fast implementation of our [asset compilation pipeline](https://github.com/travis-ci/travis-web/blob/master/AssetFile).
 Thank you so much, guys :)
-
-
-
-
-
 

--- a/blog/_posts/2012-10-24-finding-your-soul-metric.md
+++ b/blog/_posts/2012-10-24-finding-your-soul-metric.md
@@ -10,7 +10,7 @@ Travis has a history of failure. While we're not ashamed to admit that and talk
 about them in public, we're also working hard to ensure that we notice early on if
 something breaks. We want to find out about it before our users do.
 
-Over the last couple of months we've added a ton of metrics to have good insight
+Over the last couple of months we've added a ton of metrics to improve insight
 into all parts of Travis. But during these months, we couldn't find the single
 metric that would tell us if the system is doing what it's supposed to do, which
 is of course to run your builds. It took us quite a while to finally figure out
@@ -35,18 +35,18 @@ the last build started.
 Yes, it turns out to be that simple. Turns out that this it the sole defining
 metric that helps us keep a watchful eye on Travis. Just to be safe, we added
 the time since the last build finished. As a general metric we're also tracking
-the number of message currently ready to be consume in RabbitMQ. These metrics
+the number of message currently ready to be consumed in RabbitMQ. These metrics
 give us a rough clue that something is failing in our infrastructure. Here's a
 recent snapshot of what they look like when correlated:
 
-![](http://s3itch.paperplanes.de/buildvsrabbit-20121024-170411.png)
+![Graph of Messages vs Build Started/Finished](http://s3itch.paperplanes.de/buildvsrabbit-20121024-170411.png)
 
 Here's a more recent graph that shows a database latency spike not long ago and
 queues backing up as a consequence. We're still investigating why this happened,
 and we'll move to a bigger database setup soon as well. We're also spreading out
 the work load even more to keep up with it better.
 
-![](http://s3itch.paperplanes.de/graphs-20121024-182007.png)
+![Graph of Log Messages vs Log Updates](http://s3itch.paperplanes.de/graphs-20121024-182007.png)
 
 ### How can I find my soul metric?
 
@@ -85,7 +85,7 @@ started and our alerts immediately went off. Here's something visual that shows
 the latency spiking and the number of messages queueing up in our logging
 queues as a result:
 
-![](http://snapshots.librato.com/instruments/7hc3ny1p-317.png)
+![Graph of latency spike](http://snapshots.librato.com/instruments/7hc3ny1p-317.png)
 
 Notice the latency going up (green graph) and messages piling up. Suddenly the
 latency went back to almost being normal, and the queues were slowly drained.
@@ -113,7 +113,7 @@ the future.
 That little app also does threshold-based alerting to our Campfire room. I'm
 planning on adding support for Pagerduty and Prowl soon too.
 
-![](http://s3itch.paperplanes.de/alerts-20121024-165255.png)
+![travisbot messages](http://s3itch.paperplanes.de/alerts-20121024-165255.png)
 
 While there are existing tools for monitoring, metrics collection and alerting,
 there's no shame in experimenting with your own, if you're aware of the

--- a/blog/_posts/2012-11-27-shipping-new-ui-for-pro.md
+++ b/blog/_posts/2012-11-27-shipping-new-ui-for-pro.md
@@ -17,7 +17,7 @@ You can find a link to the new client on Travis Pro, we've sent a broadcast to
 everyone.
 
 Travis Pro is still in beta. If you are interested in trying it out but don't
-have an account then drop us an email to [support@travis-ci.com](support@travis-ci.com).
+have an account then drop us an email at [support@travis-ci.com](support@travis-ci.com).
 
 We are going to follow the same practice that we've followed shipping the
 client for .org: We'll make the new client available on a separate domain, in
@@ -31,7 +31,4 @@ Please help us by giving feedback on any issues, breakage or weirdness.
 If you are eager to read an overview of all the features and goodies that the
 new UI includes you can find them in the [original announcement](http://about.travis-ci.org/blog/2012-10-23-introducing-travis-cis-next-generation-web-client).
 But the gist is: overall polished, much more responsive, fast and stable, new
-features like proper urls, requeueing builds, flash messages etc.
-
-
-
+features like proper URLs, requeueing builds, flash messages etc.

--- a/blog/_posts/2012-11-28-speeding-up-your-tests.md
+++ b/blog/_posts/2012-11-28-speeding-up-your-tests.md
@@ -19,7 +19,7 @@ Travis’ [build
 matrix](http://about.travis-ci.org/docs/user/build-configuration/#The-Build-Matrix)
 feature.
 
-![](http://i.imgur.com/w8Wv1.jpg)
+![Neo dodging bullets](http://i.imgur.com/w8Wv1.jpg)
 
 Say you want to split up your unit tests and your integration tests into two
 different build jobs. They’ll run in parallel and fully utilize the available

--- a/blog/_posts/2012-11-29-coffee-office-hours.md
+++ b/blog/_posts/2012-11-29-coffee-office-hours.md
@@ -10,13 +10,13 @@ The Travis team loves two things a lot: coffee and meeting people. We also like
 to hug the people we meet. So why not combine all three and get to know users
 and customers better and meet them in person?
 
-![](http://distilleryimage5.s3.amazonaws.com/c9c1a8d20a4711e2900e22000a1cbaa0_7.jpg)
+![coffee cups on a table](http://distilleryimage5.s3.amazonaws.com/c9c1a8d20a4711e2900e22000a1cbaa0_7.jpg)
 
 Today we're announcing the Travis Coffee Office Hours. You can meet and chat
 with the Travis team and enjoy some fine coffees, and cake too. Mmmmmmm, cake.
 The coffee's on us, of course!
 
-To start things off, we'll be hanging out our favorite coffee shops in Berlin
+To start things off, we'll be hanging out at our favorite coffee shops in Berlin
 and in Wellington on Thursday, December 6. Please stop by if you want to chat
 about Travis, infrastructure, continuous integration, or anything that's on your
 mind.

--- a/blog/_posts/2012-12-05-ssl-keys-security-issue.md
+++ b/blog/_posts/2012-12-05-ssl-keys-security-issue.md
@@ -24,7 +24,7 @@ order to estimate possible damage.
 
 We have taken the following steps
 
-1. Regenerate keys for affected repos and notify maintainers
+1. Regenerated keys for affected repos and notified maintainers
 2. Add a 'regenerate key' button into the web interface
 3. Announce the issue by way of this blog post
 

--- a/blog/_posts/2012-12-06-after-script-behavior-change.md
+++ b/blog/_posts/2012-12-06-after-script-behavior-change.md
@@ -7,7 +7,7 @@ twitter: drogus
 created_at: Fri 6 Dec 2012
 ---
 
-TL;DR We're changing the `after_script` command to run regardless the test result,
+TL;DR We're changing the `after_script` command to run regardless of the test result,
 previously it was run only on success.
 
 ## What exactly will change?
@@ -19,7 +19,7 @@ were successful (ie. returned 0).  This made it virtually the same as the
 success and failure without specifying them twice in the success and failure
 stages.
 
-In order to simplify things, we change `after_script` to run at the very end,
+In order to simplify things, we changed `after_script` to run at the very end,
 i.e. after the `after_success` and `after_failure` stages. `after_script` will
 be run no matter what was returned from the previous commands. We will also
 export a `TRAVIS_TEST_RESULT` env variable, which contain the test result
@@ -40,7 +40,7 @@ If you rely on the fact that a failure in the `after_script` phase, fails the
 entire test, you should move, you should move such commands to the `script`
 phase.
 
-For example such script:
+For example, the following:
 
     script:
       - rake

--- a/blog/_posts/2012-12-13-an-update-on-infrastructure-changes.md
+++ b/blog/_posts/2012-12-13-an-update-on-infrastructure-changes.md
@@ -6,8 +6,8 @@ author: Mathias Meyer
 twitter: roidrage
 permalink: blog/2012-12-13-an-update-on-infrastructure-changes
 ---
-We've had our share of issues over the last months, and it's time we give you an
-update on what we've been doing about them.
+We've had our share of issues over the last few months, and it's time we give 
+you an update on what we've been doing about them.
 
 The most important bit up front is that we're breaking Travis down into more and
 more small apps. We traditionally had one big component, called the hub, which
@@ -27,7 +27,7 @@ volume.
 
 To give you perspective, [travis-ci.org](http://travis-ci.org) handles about
 1500 log updates per minute during peak hours, while
-[travis-ci.com](http://travis-ci.com) has to handle 2500. In situation where our
+[travis-ci.com](http://travis-ci.com) has to handle 2500. In situations where our
 log processing has temporarily backed up, it handled 4000 updates per minute.
 While that only boils down to ~66 writes per second, our current data
 model is bound to break down eventually as we scale up, as too much data needs

--- a/blog/_posts/2012-12-17-numbers.md
+++ b/blog/_posts/2012-12-17-numbers.md
@@ -7,7 +7,7 @@ twitter: konstantinhaase
 layout: post
 ---
 
-I recently gave [a presentation](https://speakerdeck.com/rkh/travis-ci) about Travis CI at [Øredev](http://oredev.org/). For this preparation, I set down with our production database and ran a few aggregations. Our schema currently makes some of these not that easy, so most of the following numbers were pretty new to us, too.
+I recently gave [a presentation](https://speakerdeck.com/rkh/travis-ci) about Travis CI at [Øredev](http://oredev.org/). For this preparation, I sat down with our production database and ran a few aggregations. Our schema currently makes some of these not that easy, so most of the following numbers were pretty new to us, too.
 
 Before you take a look at the graphs below, a word of warning: The data is not fully up to date (numbers are as of October 26).
 
@@ -15,7 +15,7 @@ Before you take a look at the graphs below, a word of warning: The data is not f
 
 ![Active Projects](/images/stats.001.png)
 
-As you can see, our number of open source projects has crossed 25k about two month ago and is now steadily growing at about 90 new projects a day.
+As you can see, our number of open source projects has crossed 25k about two months ago and is now steadily growing at about 90 new projects a day.
 
 Interestingly, if you look at the open source vs private project ratio and then compare it with the overall system activity, it is easy to see that private projects are more active on average.
 

--- a/blog/_posts/2012-12-18-travis-artifacts.md
+++ b/blog/_posts/2012-12-18-travis-artifacts.md
@@ -14,7 +14,7 @@ you can go straight to [install instructions](#How-to-use%3F).
 Travis is already very good at running your tests, but we feel that we can
 do much better job with things that happen **after** the tests have
 finished running. First step in this direction is what we call build artifacts.
-Artifacts are files, which are produced while running the tests. It may be
+Artifacts are files which are produced while running the tests. It may be
 compiled version of a library, screenshots done while running your tests in the browser
 or logs that can help with debugging test failures.
 
@@ -33,7 +33,7 @@ In order to use artifacts you need to do a couple steps:
    - `ARTIFACTS_AWS_ACCESS_KEY_ID`
    - `ARTIFACTS_AWS_SECRET_ACCESS_KEY`
 
-   Last 2 vars should be kept secret, so you should encrypt them using `travis` gem, just like this:
+   Last two vars should be kept secret, so you should encrypt them using `travis` gem, just like this:
 
        travis encrypt ARTIFACTS_AWS_ACCESS_KEY_ID=abc123 -r owner/repo_name
 
@@ -101,7 +101,7 @@ The other argument for going in such direction is that we're not yet sure what w
 we end up with. Maybe it will not evolve too much, but maybe based on use cases and
 feedback we will change a lot in a way it works.
 
-During the development of artifacts I wanted a way to run script regardless the tests result.
+During the development of artifacts I wanted a way to run scripts regardless of test results.
 There was no such hook, so I wanted to change `after_script` to behave that way.
 I also exposed the `TRAVIS_TEST_RESULT` environment variable so you can check if tests failed
 or passed at this point. This is a general purpose change in a way travis works and it will
@@ -112,7 +112,7 @@ This is also a good way to deal with things in open source in general. Sometimes
 like to make an addition to a library, which can't be accepted. It may be something that
 is a specific use case, which will not be used by a majority. It may be something that
 is not yet well formed as an idea and needs testing or maybe maintainers are just not
-interested in going that way. In such situation you can either fork the project, which
+interested in going that way. In such situations you can either fork the project, which
 is not a good solution in the long run, because you need to maintain the fork, or you can extend
 the library to allow you to plug in your extensions. I really like the latter approach, because
 not only does it make the library more flexible, but it also makes your life easier.

--- a/blog/_posts/2012-12-30-2012-retrospective.md
+++ b/blog/_posts/2012-12-30-2012-retrospective.md
@@ -13,7 +13,7 @@ happened in just a single year.
 
 If Travis CI has been a toddler when [Josh](http://github.com/joshk) and I
 started touring conferences in 2011 to tell everyone about the idea and vision
-then in 2012 it was a kid growing up, went through some heavy duty rock'n'roll
+then in 2012 it was a kid growing up, going through some heavy duty rock'n'roll
 and all night party times.
 
 In 2011 the [initial experiments](http://svenfuchs.com/2011/2/5/travis-a-distributed-build-server-tool-for-the-ruby-community)
@@ -52,7 +52,7 @@ In addition, somewhere around June we started working on the new Ember.js web
 client as well as the new API (yellow, see below) and split up the app more and
 more (red) towards the end of the year.
 
-And if you really want to stalk us more then you can find even more detailled information
+And if you really want to stalk us more then you can find even more detailed information
 [in a feature list](https://gist.github.com/0f0ede41b07653810fd1) and
 [a summary of our commit history](https://gist.github.com/f7e81d3b92505ee3c3a7).
 
@@ -181,19 +181,16 @@ One year ago Travis CI consisted of a web app, a bunch of worker machines and a
 central message crunching app called Hub. Today there's an entire small army of
 apps that all share their their part in getting your builds run:
 
-[Listener](http://github.com/travis-ci/travis-listener) picks up requests from GitHub (created Dec 2011).
-Gatekeeper
-configures them and takes care of syncing user data with GitHub (Oct 2012).
-Enqueue
-queues build jobs based on a rate limiting strategy (Oct 2012).
-[Hub](http://github.com/travis-ci/travis-hub)
-still is a central node that picks up state changes and triggers events.
-[Tasks](http://github.com/travis-ci/travis-tasks)
-sends out notifications to external targets (like Email, IRC, Campfire etc.,
-created Aug 2012).
-[Logs](http://github.com/travis-ci/travis-logs)
- does nothing else but processing logs that are streamed
-over from the workers (Aug 2012).
+- [Listener](http://github.com/travis-ci/travis-listener) picks up requests from 
+GitHub (created Dec 2011).
+- Gatekeeper configures them and takes care of syncing user data with GitHub (Oct 2012).
+- Enqueue queues build jobs based on a rate limiting strategy (Oct 2012).
+- [Hub](http://github.com/travis-ci/travis-hub) still is a central node that picks up state 
+changes and triggers events.
+- [Tasks](http://github.com/travis-ci/travis-tasks) sends out notifications to external targets 
+(like Email, IRC, Campfire etc., created Aug 2012).
+- [Logs](http://github.com/travis-ci/travis-logs) does nothing else but processing logs that 
+are streamed over from the workers (Aug 2012).
 
 There are also other apps for serving the static [web client](http://github.com/travis-ci/travis-web) and
 serving the [HTTP API](http://github.com/travis-ci/travis-api).
@@ -275,7 +272,7 @@ resources for this we will also look into follwing up on the crowdfunding
 campaign for the next year. Expect to hear more about this soon.
 
 So, if 2011 was the year of birth of the Travis CI project and 2012 was the
-year of it's childhood and youth, we hope that we can make 2013 the year of
+year of its childhood and youth, we hope that we can make 2013 the year of
 growing Travis CI up to stabilize as the most useful, efficient and well
 supported continuous integration platform out there.
 

--- a/blog/_posts/2013-01-14-quality-of-service.md
+++ b/blog/_posts/2013-01-14-quality-of-service.md
@@ -16,7 +16,7 @@ Sometimes it can appear like Travis CI was only built to run the test suite of a
 
 You will be very happy to know that this is not the case thanks to some simple Quality of Service measures we put in place late last year.
 
-When someone decides to push a lot of commits to one or many different projects and use up lots of places in the queue, Travis CI will only allow them to use up 5 worker slots at any one time. This is implemented at an owner level and not a project level which means that one user, or one organisaton, can't push commits for multiple projects and use all the workers; the rest of their jobs will enter the queue.
+When someone decides to push a lot of commits to one or many different projects and use up lots of places in the queue, Travis CI will only allow them to use up five worker slots at any one time. This is implemented at an owner level and not a project level which means that one user, or one organisaton, can't push commits for multiple projects and use all the workers; the rest of their jobs will enter the queue.
 
 And you'll be pleased to know that we're also working hard on a new VM setup which will result in more efficient use of our existing queuing and available VMs to reduce the time that everyone spends waiting for jobs to be run.  After all, we want you to receive your build results as soon as possible to keep you happy!
 

--- a/blog/_posts/2013-01-14-z-new-client.md
+++ b/blog/_posts/2013-01-14-z-new-client.md
@@ -60,6 +60,6 @@ Will print something like this:
 
 We want the Ruby library to reach 100% coverage of our API. Thus anything the web front end can do - and potentially more - will in the future be possible with this library. We would also love to add more functionality to the command line client, check out our [TODO list](https://github.com/travis-ci/travis#todo) to see what we have planned.
 
-Needless to say, this client is fully Open Source, so any contributions are very much welcome!
+Needless to say, this client is fully open source, so any contributions are very much welcome!
 
 PS: It also runs on Windows!

--- a/blog/_posts/2013-01-25-the-worker-gets-a-revamp.md
+++ b/blog/_posts/2013-01-25-the-worker-gets-a-revamp.md
@@ -15,8 +15,7 @@ Travis is broken up into various small apps, each with a very focused responsibi
 
 This might sound like a big responsibilty, and it is, but there is another piece to the worker puzzle, and that is Travis Build. [Travis Build](https://github.com/travis-ci/travis-build)'s responsibility is to know how to run a build for a particular language. For example, a Ruby project uses [Bundler](http://gembundler.com/) for dependency management, while Node uses [npm](https://npmjs.org/). And of course, these defaults are configurable and overridable.
 
-Timeouts and Stalls
--------------------
+### Timeouts and Stalls
 
 As much as we love Travis Worker and Travis Build, things aren't always pain free. If you've been using Travis for any period of time you would have possibly come across two annoying bugs, the dreaded [VMFatalError](https://travis-ci.org/westoque/phantomjs.rb/builds/3614255), and the [stalled job](https://travis-ci.org/rootpy/rootpy/jobs/3606285/#L31) (which also includes false timeouts). These issues are an awful and frustrating experience for our users, and no easier for us. I would go as far to say that every time a VM explodes or a timeout fails a test incorrectly, a German looses his lederhosen.
 
@@ -45,8 +44,7 @@ This has worked great, but it's also a bit of a hack which isn't 100% realibale.
 
 At the end of the day there is no single reason we can pinpoint and be sure of when it comes to false timeouts, it is highly likely a mixture of technologies and libraries used contributes to the problem, and it is highly likely componded by Travis code.
 
-So what have we been doing about it?
-------------------------------------
+### So what have we been doing about it?
 
 **How we run your tests**
 
@@ -64,11 +62,11 @@ Welcome to the new Travis Build, which can be found on the [sf-compile-sh](https
 
 **What we run your tests on**
 
-VirtualBox has got us very far. It was great for development, had some fantastic features like snapshots and immutable disk images, and had some great tools built around it like [Vagrant](http://www.vagrantup.com/).
+VirtualBox has gotten us very far. It was great for development, had some fantastic features like snapshots and immutable disk images, and had some great tools built around it like [Vagrant](http://www.vagrantup.com/).
 
 As we grew from one worker box to our current 24, maintenance of the VMs became a pain. Updating a worker took up to an hour as each VM on the host had to be provisioned and primed for use. Also, because of how VirtualBox works, we had to plan for how many Ruby boxes we would run, or how many Perl/Python/PHP (PPP) or JVM boxes we needed. To make a long story short, we could not easily dynamically decide what builds a host box could or would run. 
 
-And of course there are the API isuses and VirtualBox specific errors, like trying to shut down VMs which looked liked they were shutting down but were actually stuck. Initially we implemented a crude 'kill -9' trick which would detect this error and then, well, shell out and kill the VM process using it's process id, which  seemed to work for a while, but was not fool proof by any means. In fact, it was mearly a band aid around a more complicated issue of 'what does the future architecture of Travis look like?'
+And of course there are the API isuses and VirtualBox specific errors, like trying to shut down VMs which looked liked they were shutting down but were actually stuck. Initially we implemented a crude 'kill -9' trick which would detect this error and then, well, shell out and kill the VM process using its process id, which seemed to work for a while, but was not fool proof by any means. In fact, it was merely a band aid around a more complicated issue of 'what does the future architecture of Travis look like?'
 
 The great thing is we finally have the answer to this question, and are very happy to say we now know what our next-gen architecture will look like. In fact, we have been testing it with the Rails and Spree queues, and since a week ago, the JVM queue. And over the next week or two we will be moving all queues to this new setup.
 
@@ -80,8 +78,7 @@ We will save most of these details for a later blog post after we've ironed out 
 
 This is a huge maintenance relief for us as we can now focus on Travis features instead of having to maintain servers. We also pledge to update VMs more often so you have the latest and greatest services available for you to test against!
 
-But wait, there's more!
-----------------------
+### But wait, there's more!
 
 While we were at it we decided to add two often requested features to this new code base, these being **an 'errored' build state**, and **better, more flexible time outs**.
 
@@ -92,12 +89,11 @@ From now on, if any command before your actual tests are run fails we will mark 
   <figcaption>Errors in Pull Requests!</figcaption>
 </figure>
 
-The fine grained timeouts we've been using for the past year and a half were good, but they became restrictive for some. Restricting how long your app spends installing dependecies is annoying, especially when your test run might only take a fraction of the time. Instead we are now moving to a global 50 minute job timeout, and if no log output has been received in 5 minutes then we cancel the job. Why 5 minutes you say? We have found that not having log output from a job run points towards either a stalled test suite, or stalled process. A good example of this is some jobs start a background webserver but sometimes forget to stop it, causing the job to sit and wait. And of course, we mark these timeouts as errors as well!
+The fine grained timeouts we've been using for the past year and a half were good, but they became restrictive for some. Restricting how long your app spends installing dependecies is annoying, especially when your test run might only take a fraction of the time. Instead we are now moving to a global 50 minute job timeout, and if no log output has been received in five minutes then we cancel the job. Why five minutes you say? We have found that not having log output from a job run points towards either a stalled test suite, or stalled process. A good example of this is some jobs start a background webserver but sometimes forget to stop it, causing the job to sit and wait. And of course, we mark these timeouts as errors as well!
 
-So where to from here?
-----------------------
+### So where to from here?
 
-Although we have made a lot of headway, we still have a long way to go. For example, starting a VM incurs a startup cost of around 30-40 seconds, sometimes greater depending on load. We need to prestart VMs and have them waiting in a pool. We also need to remove the notion of defined queues, eg. having 30 VMs for Ruby builds and 30 for PPP means if the Ruby queue is empty and the PPP queue is knee deep in jobs, we should be dynamically allocating capacity where and when needed!
+Although we have made a lot of headway, we still have a long way to go. For example, starting a VM incurs a startup cost of around 30-40 seconds, sometimes greater depending on load. We need to prestart VMs and have them waiting in a pool. We also need to remove the notion of defined queues, e.g. having 30 VMs for Ruby builds and 30 for PPP means if the Ruby queue is empty and the PPP queue is knee deep in jobs, we should be dynamically allocating capacity where and when needed!
 
 So please be patient with us over the next couple of weeks as we roll out these changes and more. If you experience any issues please report them to our GitHub issues page on [travis-ci/travis-ci](https://github.com/travis-ci/travis-ci/issues?direction=desc&labels=feature-request&sort=updated&state=open). And, as always, free feel to drop by our IRC room (#travis on freenode) if you have any questions, comments, or advice :)
 

--- a/blog/_posts/2013-01-31-post-mortem-build-outage.md
+++ b/blog/_posts/2013-01-31-post-mortem-build-outage.md
@@ -57,7 +57,7 @@ Michael Fairley, who also had a working exploit based on our code, at 0:00 UTC.
 ### The investigation
 
 When we process a build we store the configuration in our database, so we could
-check all existing builds for any occurrances of a string starting with "!ruby",
+check all existing builds for any occurrences of a string starting with "!ruby",
 which would denote an attempt to inject code.
 
 We also investigated all commits that had parsing errors (a sign that something is
@@ -126,7 +126,7 @@ earlier this month, we should have reviewed all use of YAML files and how
 they're parsed.
 
 In hindsight it's such an obvious issue, and we should've added one and one
-right away and look at this part of Travis CI too.
+right away and looked at this part of Travis CI too.
 
 As we turned up build processing today at around 14:00 UTC for private
 repositories and 15:30 UTC for open source projects, we had to discard
@@ -135,7 +135,7 @@ handled for private projects and around 5800 for open source projects. With our
 current build capacity it would've taken us days to plow through these.
 
 We processed all of them, but moved them into an erroneous state. Should you
-rely on a specific commit to be build, you can trigger a rebuild through the UI.
+rely on a specific commit to be built, you can trigger a rebuild through the UI.
 
 Processing on <http://travis-ci.org> was unfortunately rather slow after we
 brought everything back up, we're investigating the cause.


### PR DESCRIPTION
Also includes:
- Consistent Markdown heading format
- alt text for more images
- Casing for brands with certain ways
- Spelling out numbers if under 10 unless in time, stats or similar

Still looks weird on instances of "Open Source" and "Pull Request" being title case in the middle of a sentence. Not sure about those.
