### PR TITLE
Example config for node versions with quotes

### DIFF
--- a/docs/user/languages/javascript-with-nodejs.md
+++ b/docs/user/languages/javascript-with-nodejs.md
@@ -14,8 +14,9 @@ Historically Node.js projects were built on Ruby workers but in November 2011 No
 
     language: node_js
     node_js:
-      - 0.8
-      - 0.6
+      - "0.10"
+      - "0.8"
+      - "0.6"
 
 This will make Travis run your tests against the latest (as provided by Travis maintainers, not necessary the absolutely the latest) 0.6.x branch release. 0.8 is an alias for "the most recent 0.8.x release" and so on. Please note that using exact versions (for example, 0.6.19) is highly discouraged because as versions change, your .travis.yml will get outdated and things will break.
 


### PR DESCRIPTION
According to @roidrage you should use quotes or else this will break as soon as 0.11 is released.
