### PR TITLE
add R16B to supported erlang releases

### DIFF
--- a/docs/user/languages/erlang.md
+++ b/docs/user/languages/erlang.md
@@ -14,6 +14,7 @@ Travis VMs provide 32-bit [Erlang OTP](http://www.erlang.org/download.html) rele
 
     language: erlang
     otp_release:
+       - R16B
        - R15B02
        - R15B01
        - R15B


### PR DESCRIPTION
add r16b to supported erlang releases

skip r15b03 because it had an emergency release (r15b03-1) to correct a bug that is not available
