### PR TITLE
Make it clear which user travisbot is

### DIFF
--- a/docs/user/travis-pro.md
+++ b/docs/user/travis-pro.md
@@ -79,7 +79,7 @@ post](http://about.travis-ci.org/blog/announcing-pull-request-support/) accompan
 the launch of pull requests for Travis.
 
 Currently, the only thing you need to do for our trusty travisbot to be able to
-leave comments on your pull requests is to add him as a read-only user to the
+leave comments on your pull requests is to add the "travisbot" user as a read-only user to the
 repositories tested on Travis. These steps aren't necessary for open source
 projects, travisbot loves all of them without any manual intervention.
 


### PR DESCRIPTION
Reading the documentation I wasn't completely confident which user to add to my private repository to let travis leave comments on my pull requests.  After browsing around, I'm pretty sure that it should simply be the "travisbot" user; this change avoids making other people have the same uncertainty.
