### PR TITLE
Added explicit discussion of several encrypted env var things that confused me

### DIFF
--- a/docs/user/encryption-keys.md
+++ b/docs/user/encryption-keys.md
@@ -66,6 +66,47 @@ We add to our .travis.yml file
 
 And we're done.
 
+### Detailed Discussion
+
+The way the secure var system works is is takes values on the format ```{ 'secure' => 'encrypted string' }``` in the (parsed YAML) configuration and replaces it with the decrypted string.
+
+So
+
+    notifications:
+      campfire:
+        rooms:
+          secure: "encrypted string"
+
+becomes
+
+    notifications:
+      campfire:
+        rooms: "decrypted string"
+
+while
+
+    notifications:
+      campfire:
+        rooms:
+          - secure: "encrypted string"
+
+becomes
+
+    notifications:
+      campfire:
+        rooms:
+          - "decrypted string"
+
+In the case of secure env vars
+
+    env:
+      - secure: "encrypted string"
+
+becomes
+
+    env:
+      - "decrypted string"
+
 ## Fetching the public key for your repository
 
 You can fetch the public key with Travis API, using `/repos/:owner/:name/key` or


### PR DESCRIPTION
I was working with encrypted env vars yesterday, and I was confused by several things.
- I didn't realize you needed to pass the env var name to travis encrypt.
- I wasn't sure if the key should be "secure" for all vars, or if the example was just using the name "secure."
- I also wasn't sure if you could put multiple "secure" entries in one .travis.yml.

Updated the page to say these things explicitly.  Hope it helps the next person.

Thank you for creating and maintaining travis!

Mike
