### PR TITLE
Fixed Build toolchain typo in docs

### DIFF
--- a/docs/user/ci-environment.md
+++ b/docs/user/ci-environment.md
@@ -39,7 +39,7 @@ All VM images have the following pre-installed
  * Subversion (official Ubuntu packages)
 
  
-### Compilers & Built toolchain
+### Compilers & Build toolchain
 
 GCC 4.6.x, Clang 3.1.x, make, autotools, cmake, scons.
 

--- a/docs/user/osx-ci-environment.md
+++ b/docs/user/osx-ci-environment.md
@@ -31,7 +31,7 @@ travis-ci.org uses Mac OS X 10.8.2
 Homebrew is installed and updated every time the VMs are updated. It is recommended that you run `brew update` before installing anything with Homebrew.
 
 
-### Compilers & Built toolchain
+### Compilers & Build toolchain
 
 GCC 4.2.1, Clang 4.1, make, autotools.
 


### PR DESCRIPTION
Replaced `Built toolchain` with `Build toolchain`.
