### PR TITLE
Consistently use chat.freenode.net

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -52,7 +52,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
+              <li><a href="irc://chat.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Mailing list</a></li>
               <li><a href="http://github.com/travis-ci">GitHub</a></li>
               <li><a href="http://about.travis-ci.org/blog.xml">Blog Feed</a></li>

--- a/_layouts/es.html
+++ b/_layouts/es.html
@@ -50,7 +50,7 @@
             <h2>Contacto</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
+              <li><a href="irc://chat.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Lista de Correos</a></li>
               <li><a href="http://github.com/travis-ci">Github</a></li>
             </ul>

--- a/_layouts/foundation-en.html
+++ b/_layouts/foundation-en.html
@@ -66,7 +66,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
+              <li><a href="irc://chat.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Mailing list</a></li>
             </ul>
           </div><!-- /#sidebar -->

--- a/_layouts/fr.html
+++ b/_layouts/fr.html
@@ -67,7 +67,7 @@
             <h2>Contact</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
+              <li><a href="irc://chat.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Liste de diffusion</a></li>
               <li><a href="http://github.com/travis-ci">GitHub</a></li>
             </ul>

--- a/_layouts/pt-BR.html
+++ b/_layouts/pt-BR.html
@@ -50,7 +50,7 @@
             <h2>Contato</h2>
             <ul>
               <li><a href="http://twitter.com/travisci">Twitter</a></li>
-              <li><a href="irc://irc.freenode.net/%23travis">IRC</a></li>
+              <li><a href="irc://chat.freenode.net/%23travis">IRC</a></li>
               <li><a href="http://groups.google.com/group/travis-ci">Lista de email</a></li>
               <li><a href="http://github.com/travis-ci">GitHub</a></li>
               <li><a href="http://about.travis-ci.org/blog.xml">Feed do Blog</a></li>

--- a/blog/_posts/2011-11-13-first_class_php_support_on_travis_ci.md
+++ b/blog/_posts/2011-11-13-first_class_php_support_on_travis_ci.md
@@ -27,7 +27,7 @@ Please see our [initial documentation for PHP projects](http://about.travis-ci.o
 
 In addition, we have a couple of machines lined up that we will be running PHP builds on. One of them is [Shopify](http://shopify.com): they donated a worker we have been using for Node.js projects. Another one is [ServerGrove](http://servergrove.com), experts in PHP hosting and specifically frameworks like Symfony and Zend Framework: they donated us one more machine to run PHP builds on.
 
-If you have questions, find us in #travis on irc.freenode.net, we will be happy to answer them. To stay up to date with new announcements, CI environment software updates and more, [follow us on Twitter](https://twitter.com/travisci) and [join our mailing list](https://groups.google.com/forum/#!forum/travis-ci).
+If you have questions, find us in #travis on chat.freenode.net, we will be happy to answer them. To stay up to date with new announcements, CI environment software updates and more, [follow us on Twitter](https://twitter.com/travisci) and [join our mailing list](https://groups.google.com/forum/#!forum/travis-ci).
 
 We hope you enjoy using Travis for your open source projects as much as we do. Go add your PHP projects to Travis CI and recommend your fellow PHP developers to do the same!
 

--- a/blog/_posts/2012-02-21-announcing_support_for_java_scala_and_groovy_on_travis_ci.md
+++ b/blog/_posts/2012-02-21-announcing_support_for_java_scala_and_groovy_on_travis_ci.md
@@ -74,7 +74,7 @@ Note that Clojure and Scala build tools allow testing against multiple versions 
 
 To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
-If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
+If you need help, feel free to join #travis on chat.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 
 
 

--- a/blog/_posts/2012-02-27-announcing_python_and_perl_support_on_travis_ci.md
+++ b/blog/_posts/2012-02-27-announcing_python_and_perl_support_on_travis_ci.md
@@ -93,7 +93,7 @@ Travis' build workflow usually is
 
 To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
-If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
+If you need help, feel free to join #travis on chat.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 
 
 

--- a/blog/_posts/2012-03-11-announcing_haskell_support_on_travis_ci.md
+++ b/blog/_posts/2012-03-11-announcing_haskell_support_on_travis_ci.md
@@ -67,7 +67,7 @@ By default Travis' build workflow is
 
 To learn what tools and services (MySQL, Postgres, Riak, etc.) are available in the CI environment, refer to the [CI environment](http://about.travis-ci.org/docs/user/ci-environment/) guide.
 
-If you need help, feel free to join #travis on irc.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
+If you need help, feel free to join #travis on chat.freenode.net, ping us on Twitter ([@travisci](http://twitter.com/travisci)) and ask questions on [our mailing list](https://groups.google.com/group/travis-ci).
 
 
 

--- a/blog/_posts/2012-03-27-upcoming_ubuntu_11_10_migration.md
+++ b/blog/_posts/2012-03-27-upcoming_ubuntu_11_10_migration.md
@@ -58,7 +58,7 @@ PHP 5.3.10 and 5.4.0 are maintained and work with OpenSSL 1.0 without modificati
 
 ## The Road to 11.10
 
-On April 6th, 2012 we plan to update all our VMs to use Ubuntu 11.10. We will provide the same set of tools, services, and libraries, but some of them will be newer than what we have today. Most maintained software should work without any changes on your part. If you experience any issues please drop by #travis on irc.freenode.net and we will do our best to help you.
+On April 6th, 2012 we plan to update all our VMs to use Ubuntu 11.10. We will provide the same set of tools, services, and libraries, but some of them will be newer than what we have today. Most maintained software should work without any changes on your part. If you experience any issues please drop by #travis on chat.freenode.net and we will do our best to help you.
 
 You can also try a minimalistic 11.10 image using Virtual Box and [sous chef](https://github.com/michaelklishin/sous-chef) or [Vagrant](http://vagrantup.com)
 with our [11.10 base box](http://files.travis-ci.org/boxes/bases/oneiric32_base.box).

--- a/blog/_posts/2012-06-28-ci-environment-updates.md
+++ b/blog/_posts/2012-06-28-ci-environment-updates.md
@@ -57,7 +57,7 @@ More information can be found in the [README of node-gyp](https://github.com/Too
 ## Getting Help
 
 If you have questions, please ask them on our [mailing list](https://groups.google.com/forum/?fromgroups#!forum/travis-ci) or in
-`#travis` on irc.freenode.net.
+`#travis` on chat.freenode.net.
 
 
 Happy testing!

--- a/blog/_posts/2012-08-25-ubuntu-1204-migration.md
+++ b/blog/_posts/2012-08-25-ubuntu-1204-migration.md
@@ -151,7 +151,7 @@ The exact migration date is not yet decided, but most likely this will happen in
 ## Getting Help
 
 If you have questions, please ask them on our [mailing list](https://groups.google.com/forum/?fromgroups#!forum/travis-ci) or in
-`#travis` on irc.freenode.net.
+`#travis` on chat.freenode.net.
 
 
 Happy testing!

--- a/blog/_posts/2013-03-08-preinstalled-php-extensions.md
+++ b/blog/_posts/2013-03-08-preinstalled-php-extensions.md
@@ -50,7 +50,7 @@ For more information, please refer to the [PHP extensions section](http://about.
 
 This feature is live on Travis CI for open source projects now and will be made available to [Travis Pro](http://beta.travis-ci.com) projects on the 18th of March.
 
-Unfortunately, this update may cause build failures because of incompatibilities between the extension you are trying to install and the extension already preinstalled. We encourage you to update your Travis setup to take advantage of this new feature and to report any issues you encounter on [our GitHub issues tracker](https://github.com/travis-ci/travis-ci/issues). You can also pop into #travis on irc.freenode.org if you need any help.
+Unfortunately, this update may cause build failures because of incompatibilities between the extension you are trying to install and the extension already preinstalled. We encourage you to update your Travis setup to take advantage of this new feature and to report any issues you encounter on [our GitHub issues tracker](https://github.com/travis-ci/travis-ci/issues). You can also pop into #travis on chat.freenode.net if you need any help.
 
 If you feel that there is a really important extension that should be preinstalled on Travis, feel free to [tell us](https://github.com/travis-ci/travis-ci/issues).
 

--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -159,7 +159,7 @@ permalink: api/
             "script": "RAILS_ENV=test bundle exec rake test:ci --trace", 
             "bundler_args": "--without development", 
             "notifications": {
-              "irc": "irc.freenode.org#travis", 
+              "irc": "chat.freenode.net#travis", 
               "campfire": {
                 "secure": "JJezWGD9KJY/LC2aznI3Zyohy31VTIhcTKX7RWR4C/C8YKbW9kZv3xV6Vn11\nSHxJTeZo6st2Bpv6tjlWZ+HCR09kyCNavIChedla3+oHOiuL0D4gSo+gkTNW\nUKYZz9mcQUd9RoQpTeyxvdvX+l7z62/7JwFA7txHOqxbTS8jrjc="
               }
@@ -192,7 +192,7 @@ permalink: api/
         "script": "RAILS_ENV=test bundle exec rake test:ci --trace", 
         "bundler_args": "--without development", 
         "notifications": {
-          "irc": "irc.freenode.org#travis", 
+          "irc": "chat.freenode.net#travis", 
           "campfire": {
             "secure": "JJezWGD9KJY/LC2aznI3Zyohy31VTIhcTKX7RWR4C/C8YKbW9kZv3xV6Vn11\nSHxJTeZo6st2Bpv6tjlWZ+HCR09kyCNavIChedla3+oHOiuL0D4gSo+gkTNW\nUKYZz9mcQUd9RoQpTeyxvdvX+l7z62/7JwFA7txHOqxbTS8jrjc="
           }
@@ -384,7 +384,7 @@ JSONP works with any of the above urls. The example below uses the url for build
             ".configured": "true",
             "bundler_args": "--without development",
             "notifications": {
-              "irc": "irc.freenode.org#travis"
+              "irc": "chat.freenode.net#travis"
             },
             "rvm": [
               "1.8.7",
@@ -405,7 +405,7 @@ JSONP works with any of the above urls. The example below uses the url for build
                 ".configured": "true",
                 "bundler_args": "--without development",
                 "notifications": {
-                  "irc": "irc.freenode.org#travis"
+                  "irc": "chat.freenode.net#travis"
                 },
                 "rvm": "1.8.7"
               },

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -272,4 +272,4 @@ See [Database setup](/docs/user/database-setup/) to learn how to configure a dat
 
 ### Step seven: We are here to help!
 
-For any kind of questions feel free to join our IRC channel [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis). We're there to help :)
+For any kind of questions feel free to join our IRC channel [#travis on chat.freenode.net](irc://chat.freenode.net/%23travis). We're there to help :)

--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -53,22 +53,22 @@ Also, you can specify when you want to get notified:
 You can also specify notifications sent to an IRC channel:
 
     notifications:
-      irc: "irc.freenode.org#travis"
+      irc: "chat.freenode.net#travis"
 
 Or multiple channels:
 
     notifications:
       irc:
-        - "irc.freenode.org#travis"
-        - "irc.freenode.org#some-other-channel"
+        - "chat.freenode.net#travis"
+        - "chat.freenode.net#some-other-channel"
 
 Just as with other notification types you can specify when IRC notifications will be sent:
 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
 
@@ -77,8 +77,8 @@ You also have the possibility to customize the message that will be sent to the 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         template:
           - "%{repository} (%{commit}) : %{message} %{foo} "
           - "Build details: %{build_url}"
@@ -108,8 +108,8 @@ If you want the bot to use notices instead of regular messages the `use_notice` 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true
@@ -119,8 +119,8 @@ and if you want the bot to not join before the messages are sent, and part after
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true

--- a/es/docs/user/getting-started.md
+++ b/es/docs/user/getting-started.md
@@ -200,4 +200,4 @@ Mira [Configuración de Base de datos](/docs/user/database-setup/) para aprender
 
 ### Paso 7: Estamos aquí para ayudar!
 
-Para cualquier duda sientete libre de conectarte a nuestro canal de IRC [#travis en irc.freenode.net](irc://irc.freenode.net/%23travis). Estamos para ayudarte :)
+Para cualquier duda sientete libre de conectarte a nuestro canal de IRC [#travis en chat.freenode.net](irc://chat.freenode.net/%23travis). Estamos para ayudarte :)

--- a/es/index.md
+++ b/es/index.md
@@ -30,4 +30,4 @@ Los servicios y librerías que hace posible travis-ci.org están [alojadas en Gi
 
 ## Conoce al Equipo
 
-Si sientes que este es un gran proyecto visitanos en [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis) y saluda! Y no olvides de visitar el  [Travis Blog](/blog/)!
+Si sientes que este es un gran proyecto visitanos en [#travis on chat.freenode.net](irc://chat.freenode.net/%23travis) y saluda! Y no olvides de visitar el  [Travis Blog](/blog/)!

--- a/fr/2011/welcome-to-travis.md
+++ b/fr/2011/welcome-to-travis.md
@@ -9,4 +9,4 @@ Travis CI est un système open-source d'intégration continue, pour la communaut
 Nous prévoyons d'avoir un blog sous peu mais pour l'instant vous pouvez
 lire nos *idées initiales* sur le [blog en anglais de Sven](http://svenfuchs.com/2011/2/5/travis-a-distributed-build-server-tool-for-the-ruby-community") et lire les diapositives des présentations que nous avons faites lors de conférences (dont [Ruby Lugdunum](http://rulu.eu), à Lyon) et User Groups Ruby.
 
-Si vous souhaitez nous rejoindre sur IRC, rendez-vous sur [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis)
+Si vous souhaitez nous rejoindre sur IRC, rendez-vous sur [#travis on chat.freenode.net](irc://chat.freenode.net/%23travis)

--- a/fr/docs/dev/api.md
+++ b/fr/docs/dev/api.md
@@ -63,7 +63,7 @@ permalink: api/
           ".configured": "true",
           "bundler_args": "--without development",
           "notifications": {
-            "irc": "irc.freenode.org#travis"
+            "irc": "chat.freenode.net#travis"
           },
           "rvm": [
             "1.8.7",
@@ -84,7 +84,7 @@ permalink: api/
               ".configured": "true",
               "bundler_args": "--without development",
               "notifications": {
-                "irc": "irc.freenode.org#travis"
+                "irc": "chat.freenode.net#travis"
               },
               "rvm": "1.8.7"
             },
@@ -133,7 +133,7 @@ permalink: api/
         ".configured": "true",
         "bundler_args": "--without development",
         "notifications": {
-          "irc": "irc.freenode.org#travis"
+          "irc": "chat.freenode.net#travis"
         },
         "rvm": "1.8.7"
       },

--- a/fr/docs/user/build-configuration.md
+++ b/fr/docs/user/build-configuration.md
@@ -152,7 +152,7 @@ Travis CI notifie par défaut :
 Vous pouvez aussi spécifier un channel IRC à notifier :
 
     notifications:
-      irc: "irc.freenode.org#travis"
+      irc: "chat.freenode.net#travis"
 
 <h3>Build seulement certaines branches</h3>
 

--- a/fr/docs/user/getting-started.md
+++ b/fr/docs/user/getting-started.md
@@ -201,4 +201,4 @@ Lisez [Configurer une base de données](/fr/docs/user/database-setup/) pour appr
 
 ### Etape n°7 : Nous sommes là pour vous aider !
 
-Quelque soit votre question, n'hésitez pas à rejoindre notre canal IRC [#travis sur irc.freenode.net](irc://irc.freenode.net/%23travis). On sera là pour vous aider ;). Bien que la lingua franca du canal soit l'anglais, vous pourrez aussi y trouver quelques francophones pour vous aider !
+Quelque soit votre question, n'hésitez pas à rejoindre notre canal IRC [#travis sur chat.freenode.net](irc://chat.freenode.net/%23travis). On sera là pour vous aider ;). Bien que la lingua franca du canal soit l'anglais, vous pourrez aussi y trouver quelques francophones pour vous aider !

--- a/fr/index.md
+++ b/fr/index.md
@@ -30,5 +30,5 @@ Les services et les librairies qui font fonctionner travis-ci.org sont [héberg�
 
 ## Rencontrez l'équipe
 
-N'hésitez pas à venir nous passer le bonjour sur [#travis sur irc.freenode.net](irc://irc.freenode.net/%23travis) si vous trouvez le projet génial !
+N'hésitez pas à venir nous passer le bonjour sur [#travis sur chat.freenode.net](irc://chat.freenode.net/%23travis) si vous trouvez le projet génial !
 Et n'oubliez pas de jeter un oeil sur le [Blog](/blog/) !

--- a/index.md
+++ b/index.md
@@ -32,4 +32,4 @@ Services and libraries that make travis-ci.org work are [hosted on GitHub](https
 
 ## Meet the Team
 
-If you feel like this is a great project then jump into [#travis on irc.freenode.net](irc://irc.freenode.net/%23travis) and say hi! And don't forget to check out the [Travis Blog](/blog/)!
+If you feel like this is a great project then jump into [#travis on chat.freenode.net](irc://chat.freenode.net/%23travis) and say hi! And don't forget to check out the [Travis Blog](/blog/)!

--- a/pt-BR/docs/dev/api.md
+++ b/pt-BR/docs/dev/api.md
@@ -65,7 +65,7 @@ permalink: api/
           ".configured": "true",
           "bundler_args": "--without development",
           "notifications": {
-            "irc": "irc.freenode.org#travis"
+            "irc": "chat.freenode.net#travis"
           },
           "rvm": [
             "1.8.7",
@@ -86,7 +86,7 @@ permalink: api/
               ".configured": "true",
               "bundler_args": "--without development",
               "notifications": {
-                "irc": "irc.freenode.org#travis"
+                "irc": "chat.freenode.net#travis"
               },
               "rvm": "1.8.7"
             },
@@ -135,7 +135,7 @@ permalink: api/
         ".configured": "true",
         "bundler_args": "--without development",
         "notifications": {
-          "irc": "irc.freenode.org#travis"
+          "irc": "chat.freenode.net#travis"
         },
         "rvm": "1.8.7"
       },
@@ -178,7 +178,7 @@ JSONP works with any of the above urls. The example below uses the url for build
             ".configured": "true",
             "bundler_args": "--without development",
             "notifications": {
-              "irc": "irc.freenode.org#travis"
+              "irc": "chat.freenode.net#travis"
             },
             "rvm": [
               "1.8.7",
@@ -199,7 +199,7 @@ JSONP works with any of the above urls. The example below uses the url for build
                 ".configured": "true",
                 "bundler_args": "--without development",
                 "notifications": {
-                  "irc": "irc.freenode.org#travis"
+                  "irc": "chat.freenode.net#travis"
                 },
                 "rvm": "1.8.7"
               },

--- a/pt-BR/docs/user/build-configuration.md
+++ b/pt-BR/docs/user/build-configuration.md
@@ -365,22 +365,22 @@ Also, you can specify when you want to get notified:
 You can also specify notifications sent to an IRC channel:
 
     notifications:
-      irc: "irc.freenode.org#travis"
+      irc: "chat.freenode.net#travis"
 
 Or multiple channels:
 
     notifications:
       irc:
-        - "irc.freenode.org#travis"
-        - "irc.freenode.org#some-other-channel"
+        - "chat.freenode.net#travis"
+        - "chat.freenode.net#some-other-channel"
 
 Just as with other notification types you can specify when IRC notifications will be sent:
 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
 
@@ -389,8 +389,8 @@ You also have the possibility to customize the message that will be sent to the 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         template:
           - "%{repository_url} (%{commit}) : %{message} %{foo} "
           - "Build details: %{build_url}"
@@ -411,8 +411,8 @@ If you want the bot to use notices instead of regular messages the `use_notice` 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true
@@ -422,8 +422,8 @@ and if you want the bot to not join before the messages are sent, and part after
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true

--- a/pt-BR/docs/user/getting-started.md
+++ b/pt-BR/docs/user/getting-started.md
@@ -200,4 +200,4 @@ Leia [Configuração de Banco de Dados](/pt-BR/docs/user/database-setup/) para a
 
 ### Sétimo passo: Estamos aqui para ajudar!
 
-Para qualquer tipo de pergunta, sinta-se livre para entrar em nosso canal de IRC [#travis na rede irc.freenode.net](irc://irc.freenode.net/%23travis). Estamos aqui para ajudar! :)
+Para qualquer tipo de pergunta, sinta-se livre para entrar em nosso canal de IRC [#travis na rede chat.freenode.net](irc://chat.freenode.net/%23travis). Estamos aqui para ajudar! :)

--- a/pt-BR/docs/user/notifications.md
+++ b/pt-BR/docs/user/notifications.md
@@ -53,22 +53,22 @@ Also, you can specify when you want to get notified:
 You can also specify notifications sent to an IRC channel:
 
     notifications:
-      irc: "irc.freenode.org#travis"
+      irc: "chat.freenode.net#travis"
 
 Or multiple channels:
 
     notifications:
       irc:
-        - "irc.freenode.org#travis"
-        - "irc.freenode.org#some-other-channel"
+        - "chat.freenode.net#travis"
+        - "chat.freenode.net#some-other-channel"
 
 Just as with other notification types you can specify when IRC notifications will be sent:
 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
 
@@ -77,8 +77,8 @@ You also have the possibility to customize the message that will be sent to the 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         template:
           - "%{repository} (%{commit}) : %{message} %{foo} "
           - "Build details: %{build_url}"
@@ -108,8 +108,8 @@ If you want the bot to use notices instead of regular messages the `use_notice` 
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true
@@ -119,8 +119,8 @@ and if you want the bot to not join before the messages are sent, and part after
     notifications:
       irc:
         channels:
-          - "irc.freenode.org#travis"
-          - "irc.freenode.org#some-other-channel"
+          - "chat.freenode.net#travis"
+          - "chat.freenode.net#some-other-channel"
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
         use_notice: true

--- a/pt-BR/index.md
+++ b/pt-BR/index.md
@@ -32,4 +32,4 @@ Os serviços e bibliotecas que fazem o travis-ci.org funcionar estão [disponív
 
 ## Encontre o time
 
-Se você acha que este é um grande projeto, então vá para o [#travis nada rede irc.freenode.net](irc://irc.freenode.net/%23travis) e diga oi! E não se esqueça de checar o [Travis Blog](/blog/)!
+Se você acha que este é um grande projeto, então vá para o [#travis nada rede chat.freenode.net](irc://chat.freenode.net/%23travis) e diga oi! E não se esqueça de checar o [Travis Blog](/blog/)!


### PR DESCRIPTION
- freenode.org is a redirect to freenode.net.
- chat.freenode.net is now the canonical entry point,
  replacing irc.freenode.net.

See also http://freenode.net/irc_servers.shtml
