### PR TITLE
Updated doc that redis is started on boot

### DIFF
--- a/docs/user/database-setup.md
+++ b/docs/user/database-setup.md
@@ -205,15 +205,7 @@ Memcached uses stock configuration and binds to localhost.
 
 ### Redis
 
-Redis is **not started on boot**. To make Travis CI start the service for you, add
-
-    services:
-      - redis-server
-
-to your `.travis.yml`.
-
-Redis uses stock configuration and is available on localhost.
-
+Redis is **started on boot**, uses stock configuration and is available on localhost.
 
 ### Cassandra
 


### PR DESCRIPTION
From my build log, I found that redis is started on boot, but the documentation has not been updated yet.

https://travis-ci.org/twinh/widget/jobs/8530884#L14

```
$ sudo service redis-server start
start: Job is already running: redis-server
```
