### PR TITLE
Fix typo in SDK section of Java docs

### DIFF
--- a/docs/user/languages/java.md
+++ b/docs/user/languages/java.md
@@ -84,8 +84,7 @@ To test against OpenJDK 7 and Oracle JDK 7:
       - openjdk7
       - oraclejdk7
 
-Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided and because it is EOL in November 2012,
-will not be provided.
+Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided and because it is EOL as of November 2012.
 
 JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.
 


### PR DESCRIPTION
Simple little typo fix for the Java documentation.
