### PR TITLE
Updating jekyll's commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to run a local Web server that will serve documentation site, run:
 
 and then open [localhost:4000](http://localhost:4000/) in your browser. 
 
-To regenerate automatically the HTML pages when you make changes to Markdown source files, use
+To regenerate the HTML pages automatically when you make changes to Markdown source files, use
 
     ./bin/jekyll serve --watch
 


### PR DESCRIPTION
The serve and no-auto commands are deprecated.
