### PR TITLE
Update Go version availability

### DIFF
--- a/docs/user/languages/go.md
+++ b/docs/user/languages/go.md
@@ -12,14 +12,14 @@ This guide covers build environment and configuration topics specific to Go proj
 
 Travis VMs are 64 bit and currently provide
 
- * go 1.0
+ * any tagged version of Go (via gvm)
  * core GNU build toolchain (autotools, make), cmake, scons
 
 Go projects on travis-ci.org assume you use Make or straight Go build tool by default.
 
 ## Specifying a Go version to use
 
-Travis CI supports Go 1.0, which is installed by default, but you can also use 1.1 and the latest Go version from tip.
+Travis CI uses gvm, so you can use any tagged version of Go or use `tip` to get the latest version.
 
     go:
       - 1.0


### PR DESCRIPTION
Correct me if I am wrong, but according to [this](http://changelog.travis-ci.com/post/52382357394/added-support-for-go-1-1), Go 1.1 and latest version are both available on Travis VMs. This PR removes conflicting information likely left behind after the change.
