### PR TITLE
Add encryption of deploy api key information

### DIFF
--- a/docs/user/encryption-keys.md
+++ b/docs/user/encryption-keys.md
@@ -7,8 +7,7 @@ permalink: encryption-keys/
 Travis generates a pair of private and public RSA keys which can be used
 to encrypt information which you will want to put into the `.travis.yml` file and
 still keep it private. Currently we allow encryption of
-[environment variables](/docs/user/build-configuration/#Secure-environment-variables)
-and notification settings.
+[environment variables](/docs/user/build-configuration/#Secure-environment-variables), notification settings, and deploy api keys.
 
 ## Usage
 


### PR DESCRIPTION
According to the docs, only environment variables and notifications can benefit from encryption keys, but according to http://about.travis-ci.org/docs/user/deployment/ , we should be able to encrypt deploy api keys as well.
