### PR TITLE
Explain that Ubuntu 12.04 only includes Python 2.7 system packages

### DIFF
--- a/docs/user/languages/python.md
+++ b/docs/user/languages/python.md
@@ -46,6 +46,8 @@ For the full up-to-date list of provided Python versions, see our [CI environmen
 
 [CI Environment](/docs/user/ci-environment/) uses separate virtualenv instances for each Python version. System Python is not used and should not be relied on. If you need to install Python packages, do it via pip and not apt.
 
+If you decide to use apt anyway, note that Python system packages only include Python 2.7 libraries on Ubuntu 12.04 LTS. This means that the packages installed from the repositories are not available in other virtualenvs even if you use the --system-site-packages option.
+
 ### PyPy Support
 
 We provide the most recent stable release of PyPy via [PyPy Team's Releases PPA](https://launchpad.net/~pypy/+archive/ppa). For pure Python projects,


### PR DESCRIPTION
The docs clearly recommend not to rely on the Python system packages, but some users may still find them very useful — especially if the dependencies include lots of C code (NumPy, SciPy) that would take a long time to compile. Warn them that --system-site-packages only works in the Python 2.7 virtualenv.
