### PR TITLE
gsub(/secure\.(travis-ci\.org)/) { $1 } for fr and pt-BR

### DIFF
--- a/fr/docs/user/status-images.md
+++ b/fr/docs/user/status-images.md
@@ -22,7 +22,7 @@ Or RDoc:
 
     {<img src="http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png" />}[http://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME]]
 
-Travis CI's own status button looks like this: [![Build Status](https://secure.travis-ci.org/travis-ci/travis-ci.png)](http://travis-ci.org/travis-ci/travis-ci)	
+Travis CI's own status button looks like this: [![Build Status](https://travis-ci.org/travis-ci/travis-ci.png)](http://travis-ci.org/travis-ci/travis-ci)	
  
 
 ### Specifying branches
@@ -39,6 +39,6 @@ Specify a `?branch=` parameter in the URI. Split branches with a comma if you wa
 
 The SSL url is:
 
-    https://secure.travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png
+    https://travis-ci.org/[YOUR_GITHUB_USERNAME]/[YOUR_PROJECT_NAME].png
 
 

--- a/pt-BR/docs/user/status-images.md
+++ b/pt-BR/docs/user/status-images.md
@@ -14,28 +14,28 @@ Nós recomendamos que você leia o [Guia de Início](/pt-BR/docs/user/getting-st
 
 Após adicionar o seu projeto ao Travis, você pode utilizar os botões de status para exibir o estado atual dos seus projetos no seu arquivo `README` do GitHub ou no site do seu projeto.
 
-    https://secure.travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png
+    https://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png
 
 O HTTPS é utilizado para que o GitHub não armazene a imagem no cache.
 
 ## Adicionando Imagens de Status em Arquivos README
 
 Utilizando Textile, mostrar o botão de estado (incluindo um link para a página do seu projeto no Travis) é tão simples quanto adicionar o seguinte no seu `README`:
-    "!https://secure.travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png!":http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO]
+    "!https://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png!":http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO]
 
 Ou, caso esteja utilizando markdown:
 
-    [![Build Status](https://secure.travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png)](http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO])
+    [![Build Status](https://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png)](http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO])
 
 Ou RDoc:
 
-    {<img src="https://secure.travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png" />}[http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO]]
+    {<img src="https://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png" />}[http://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO]]
 
-O botão de status do Travis CI aparece assim: [![Build Status](https://secure.travis-ci.org/travis-ci/travis-ci.png)](http://travis-ci.org/travis-ci/travis-ci)
+O botão de status do Travis CI aparece assim: [![Build Status](https://travis-ci.org/travis-ci/travis-ci.png)](http://travis-ci.org/travis-ci/travis-ci)
 
 ## Estado do Build de Branches Específicos
 
 É possível limitar o impacto deste botão em apenas alguns branches. Por exemplo, você pode não querer incluir branches de novas funcionalidades, que podem falhar mas que não significa que o projeto em si falhou.
 
 Especifique um parâmetro `?branch=` na URI. Caso precise especificar vários, separe os branches com uma vírgula.
-    https://secure.travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png?branch=master,staging,production
+    https://travis-ci.org/[SEU_USUARIO_GITHUB]/[NOME_DO_SEU_PROJETO].png?branch=master,staging,production


### PR DESCRIPTION
9556d9a03781c3872fd356f92ada7a1a589be5ee updated English document only, so fr and pt-BR documents are still telling us to anchor to the old host.
