### PR TITLE
Warn users to encrypt their notification API tokens

### DIFF
--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -150,6 +150,10 @@ Notifications can also be sent to Campfire chat rooms, using the following forma
 * *api token*: is the token of the user you want to use to post the notifications.
 * *room id*: this is the room id, not the name.
 
+> Note: We highly recommend you [encrypt](/docs/user/encryption-keys/) this value if your .travis.yml is stored in a public repository:
+
+    travis encrypt subdomain:api_token@room_id --add notifications.campfire.rooms
+
 You can also customise the notifications, like with IRC notifications:
 
     notifications:
@@ -172,6 +176,10 @@ Notifications can be sent to your Flowdock Team Inbox using the following format
 
 * *api token*: is your API Token for the Team Inbox you wish to notify. You may pass multiple tokens as a comma separated string or an array.
 
+> Note: We highly recommend you [encrypt](/docs/user/encryption-keys/) this value if your .travis.yml is stored in a public repository:
+
+    travis encrypt api_token --add notifications.flowdock
+
 ## HipChat notification
 
 Notifications can be sent to your HipChat chat rooms using the following format:
@@ -182,6 +190,10 @@ Notifications can be sent to your HipChat chat rooms using the following format:
 
 * *api token*: token of the user you want to use to post the notifications.
 * *room name*: name of the room you want to notify.
+
+> Note: We highly recommend you [encrypt](/docs/user/encryption-keys/) this value if your .travis.yml is stored in a public repository:
+
+    travis encrypt api_token@room_name --add notifications.hipchat.rooms
 
 HipChat notifications support templates too, so you can customize the appearance of the notifications, e.g. reduce it to a single line:
 


### PR DESCRIPTION
Many users will search the docs and jump straight to the Notifications page to figure out how to hook up Campfire/HipChat/Flowdock etc. Many of them will not think to take the additional step to read about the encryption options available. There is plenty evidence of this in the field...

This change is similar to https://github.com/travis-ci/travis-ci.github.com/pull/308 but goes a little further by adding an explicit notice in each section that suggests using a private API token, and providing an example command line. I felt it was important to repeat the language in each section, as users are likely to only read the section relevant to the service they care about.
