### PR TITLE
Fix navigation active link for Japanese layout

### DIFF
--- a/_layouts/ja.html
+++ b/_layouts/ja.html
@@ -26,11 +26,11 @@
         <ul>
           <li><a href="/blog/">ブログ</a></li>
           <li><a href="/docs/">ドキュメント</a></li>
-          <li class="english lang active"><a href="/">English</a></li>
+          <li class="english lang"><a href="/">English</a></li>
           <li class="french lang"><a href="/fr/">Français</a></li>
           <li class="spanish lang"><a href="/es/">Español</a></li>
           <li class="portuguese lang"><a href="/pt-BR/">Português</a></li>
-          <li class="japanese lang"><a href="/ja/">日本語</a></li>
+          <li class="japanese lang active"><a href="/ja/">日本語</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
The active class was set on the English list item instead of the Japanese list item.
