### PR TITLE
Add missing ALT tags for images

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,1 +1,1 @@
-<a href="http://travis-ci.org/" class="logo-home"><img src="/images/travisci-small.png"></a>
+<a href="http://travis-ci.org/" class="logo-home"><img src="/images/travisci-small.png" alt="Travis Logo"></a>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -52,7 +52,7 @@
       <div class="wrapper">
         <div class="large-6 columns left">
           <div id="travis-logo">
-            <img src="/images/travis-mascot-200px.png" id="travis-mascot">
+            <img src="/images/travis-mascot-200px.png" id="travis-mascot" alt="Travis Mascot">
           </div>
           <div id="travis-address">
             <p>&copy; 2013 Travis CI GmbH,<br> Prinzessinnenstr. 20, 10969 Berlin, Germany</p>
@@ -69,7 +69,7 @@
             </ul>
           </div>
           <div id="berlin-sticker">
-            <img src="/images/made-in-berlin-badge.png" id="made-in-berlin">
+            <img src="/images/made-in-berlin-badge.png" id="made-in-berlin" alt="Made in Berlin Badge">
           </div>
         </div>
       </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@ layout: blog
           {% for gravatar_pair in site.gravatars %}
             {% for gravatar in gravatar_pair %}
               {% if gravatar[0] == post.twitter %}
-                <img src="https://secure.gravatar.com/avatar/{{ gravatar[1] }}"/>
+                <img src="https://secure.gravatar.com/avatar/{{ gravatar[1] }}" alt="{{ post.author }}'s Gravatar"/>
               {% endif %}
             {% endfor %}
           {% endfor %}


### PR DESCRIPTION
Basic alt tagging (accessibility FTW), but currently doesn't cover the i18n versions. I figure @saltinejustine might be generalizing the footer, so I didn't add them.
