### PR TITLE
Update portuguese translation of Java documentation

### DIFF
--- a/pt-BR/docs/user/languages/java.md
+++ b/pt-BR/docs/user/languages/java.md
@@ -104,3 +104,4 @@ O JDK 7 possui compatibilidade com as versões anteriores, e nós achamos que é
 * [RESThub](https://github.com/resthub/resthub-spring-stack/blob/master/.travis.yml)
 * [Joni](https://github.com/jruby/joni/blob/master/.travis.yml), implementação de expressões regulares do JRuby
 * [Android](https://github.com/leviwilson/android-travis-ci-example/blob/master/.travis.yml), usando o [maven-android-plugin](http://code.google.com/p/maven-android-plugin/)
+* [Android](http://blog.crowdint.com/2013/05/24/android-builds-on-travis-ci-with-gradle.html), usando o [novo sistema de build com Gradle](http://tools.android.com/tech-docs/new-build-system)


### PR DESCRIPTION
Also, includes the new software versions to stay in sync with the updates on #370.

Still, I have a question: the portuguese documentation have a mention about the Travis environment using maven mirrors. The equivalent section doesn't exists in the actual english documentation. Still worth mentioning in docs?

What's better: 1-) remove the pt-BR mention 2-) put the docs back to english version 3-) don't touch it?

Thanks for the attention!

cc/ @gildegoma
