### PR TITLE
Updated the default pip command to reflect travis-build.

### DIFF
--- a/docs/user/languages/python.md
+++ b/docs/user/languages/python.md
@@ -101,7 +101,7 @@ By default Travis CI use `pip` to manage your project's dependencies. It is poss
 
 The exact default command is
 
-    pip install -r requirements.txt --use-mirrors
+    pip install -r requirements.txt
 
 which is very similar to what [Heroku build pack for Python](https://github.com/heroku/heroku-buildpack-python/) uses.
 


### PR DESCRIPTION
Because of: https://github.com/travis-ci/travis-build/pull/159, the default pip command changed.
