### PR TITLE
Update docs to reflect new Ruby versions

### DIFF
--- a/docs/user/build-configuration.md
+++ b/docs/user/build-configuration.md
@@ -251,7 +251,7 @@ Ruby projects specify releases they need to be tested against using `rvm` key:
       - "1.9.3"
       - "1.9.2"
       - jruby-19mode
-      - rbx-19mode
+      - rbx
       - jruby-18mode
       - "1.8.7"
 
@@ -282,7 +282,7 @@ You can specify more than one environment variable per item in the `env` array:
 
     rvm:
       - 1.9.3
-      - rbx-18mode
+      - rbx
     env:
       - FOO=foo BAR=bar
       - FOO=bar BAR=foo
@@ -389,7 +389,7 @@ Please take into account that Travis CI is an open source service and we rely on
       - 1.8.7 # (current default)
       - 1.9.2
       - 1.9.3
-      - rbx-18mode
+      - rbx
       - jruby
       - ruby-head
       - ree

--- a/docs/user/ci-environment.md
+++ b/docs/user/ci-environment.md
@@ -344,18 +344,20 @@ Python 2.4 and Jython *are not supported* and there are no plans to support them
 * 2.0.0
 * 1.9.3 (default)
 * 1.9.2
-* jruby-18mode (1.7.4 in Ruby 1.8 mode)
-* jruby-19mode (1.7.4 in Ruby 1.9 mode)
-* rbx-18mode (alternative alias: rbx)
-* rbx-19mode (in Ruby 1.9 mode)
-* ruby-head  (upgraded every 3-4 weeks)
-* jruby-head (upgraded every 3-4 weeks)
+* jruby-18mode (1.7.8 in Ruby 1.8 mode)
+* jruby-19mode (1.7.8 in Ruby 1.9 mode)
+* ruby-head  (upgraded every time CI passes)
+* jruby-head (upgraded every time CI passes)
 * 1.8.7
 * ree (2012.02)
 
 [Ruby 1.8.6 and 1.9.1 are no longer provided on travis-ci.org](https://twitter.com/travisci/status/114926454122364928).
 
 Rubies are built using [RVM](http://rvm.io/) that is installed per-user and sourced from `~/.bashrc`.
+
+These are only the pre-installed versions of Ruby. RVM is able to install other
+versions on demand. For example, to test against Rubinius 2.2.1, you can use
+`rbx-2.2.1` and RVM will download binaries on-demand.
 
 ### Bundler version
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -200,8 +200,7 @@ Learn more about [.travis.yml options for Python projects](/docs/user/languages/
       - "1.9.3"
       - jruby-18mode # JRuby in 1.8 mode
       - jruby-19mode # JRuby in 1.9 mode
-      - rbx-18mode
-      - rbx-19mode
+      - rbx
     # uncomment this line if your project needs to run something other than `rake`:
     # script: bundle exec rspec spec
 


### PR DESCRIPTION
I listed the installed versions here: https://travis-ci.org/henrikhodne-test/travis-test/builds/14669148#L60

Note that jruby-18mode currently does not work, see travis-ci/travis-ci#1679.
