### PR TITLE
Indenting the code example for s3 multiple-bucket deployment

### DIFF
--- a/docs/user/deployment/s3.md
+++ b/docs/user/deployment/s3.md
@@ -79,17 +79,18 @@ Often, you want to upload only to a specific S3 Folder. You can use the `upload-
 ### Deploy to Multiple Buckets:
 
 If you want to upload to multiple buckets, you can do this:
-	deploy:
-      - provider: s3
-        access_key_id: "YOUR AWS ACCESS KEY"
-        secret_access_key: "YOUR AWS SECRET KEY"
-        bucket: "S3 Bucket"
-        skip_cleanup: true
-      - provider: s3
-        access_key_id: "YOUR AWS ACCESS KEY"
-        secret_access_key: "YOUR AWS SECRET KEY"
-        bucket: "Second S3 Bucket"
-        skip_cleanup: true
+
+    deploy:
+        - provider: s3
+          access_key_id: "YOUR AWS ACCESS KEY"
+          secret_access_key: "YOUR AWS SECRET KEY"
+          bucket: "S3 Bucket"
+          skip_cleanup: true
+        - provider: s3
+          access_key_id: "YOUR AWS ACCESS KEY"
+          secret_access_key: "YOUR AWS SECRET KEY"
+          bucket: "Second S3 Bucket"
+          skip_cleanup: true
 
 ### Branch to release from
 


### PR DESCRIPTION
so that it is syntax highlighted and monospace rather than flowing from the preceding sentence.
