### PR TITLE
Fix Custom Deployment documentation

### DIFF
--- a/docs/user/deployment/custom.md
+++ b/docs/user/deployment/custom.md
@@ -6,25 +6,28 @@ permalink: custom/
 
 You can easily deploy to your own server the way you would deploy from your local machine by adding a custom [`after_success`](/docs/user/build-configuration/#Define-custom-build-lifecycle-commands) step.
 
-### FTP
+### FTP, SFTP, SCP, etc.
 
     env:
       global:
-        - "FTP_USER=user"
-        - "FTP_PASSWORD=password"
-    after_success:
-        "wget -r ftp://server.com/ --user $FTP_USER --password $FTP_PASSWORD"
+        - "DEPLOY_URL=ftp://user:password@example.com"
+    after_success: |
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+        find . -type f -exec curl --ftp-create-dirs -T {} $DEPLOY_URL/{}
+      fi
 
-The env variables `FTP_USER` and `FTP_PASSWORD` can also be [encrypted](/docs/user/encryption-keys/).
+The deploy URL can also be [encrypted](/docs/user/encryption-keys/).
 
 ### Git
 
-This should also work with services you can deploy to via git.
-
-    after_success:
-      - chmod 600 .travis/deploy_key.pem # this key should have push access
-      - ssh-add .travis/deploy_key.pem
-      - git remote add deploy DEPLOY_REPO_URI_GOES_HERE
-      - git push deploy
+    env:
+      global:
+        - "DEPLOY_URL=git@example.com:repo.git"
+    after_success: |
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+        chmod 600 .travis/deploy_key.pem # this key should have push access
+        ssh-add .travis/deploy_key.pem
+        git push $DEPLOY_URL
+      fi
 
 See ["How can I encrypt files that include sensitive data?"](/docs/user/travis-pro/#How-can-I-encrypt-files-that-include-sensitive-data%3F) if you don't want to commit the private key unencrypted to your repository.


### PR DESCRIPTION
Among other things, the old documentation didn't filter against pull requests, meaning that _any pull request filed will result in the content of that PR being deployed to the server_.
